### PR TITLE
Add internal StarRocks parameter documentation

### DIFF
--- a/param-docs/01_query_optimization.yml
+++ b/param-docs/01_query_optimization.yml
@@ -1,0 +1,1648 @@
+# StarRocks Parameter Dictionary - Query Optimization
+# CBO rules, rewrite toggles, predicate pushdown, aggregate optimization
+
+query_optimization:
+
+  cbo_join_reorder:
+
+    - name: "cbo_max_reorder_node_use_exhaustive"
+      type: Integer
+      default: 4
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of join nodes to consider for exhaustive join reorder enumeration.
+        If the number of joins exceeds this, the optimizer falls back to DP or greedy algorithms.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 407
+            context: "constant CBO_MAX_REORDER_NODE_USE_EXHAUSTIVE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1711
+            context: "@VarAttr field cboMaxReorderNodeUseExhaustive = 4"
+        thrift_propagation: null
+      behavior:
+        low_values: "Only small join graphs use exhaustive search"
+        high_values: "More joins use exhaustive (optimal) search but planning is slower"
+      related_variables:
+        - "cbo_max_reorder_node_use_dp"
+        - "cbo_max_reorder_node_use_greedy"
+        - "cbo_reorder_threshold_use_exhaustive"
+        - "cbo_max_reorder_node"
+
+    - name: "cbo_reorder_threshold_use_exhaustive"
+      type: Integer
+      default: 6
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Threshold for the number of relations in a join group before switching from
+        exhaustive to DP-based join reordering.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 837
+            context: "constant CBO_REORDER_THRESHOLD_USE_EXHAUSTIVE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2814
+            context: "@VarAttr field cboReorderThresholdUseExhaustive = 6"
+        thrift_propagation: null
+      related_variables:
+        - "cbo_max_reorder_node_use_exhaustive"
+
+    - name: "cbo_enable_dp_join_reorder"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables dynamic programming based join reorder algorithm. Used for medium-sized
+        join graphs where exhaustive is too expensive but greedy is too imprecise.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 408
+            context: "constant CBO_ENABLE_DP_JOIN_REORDER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1717
+            context: "@VarAttr field cboEnableDPJoinReorder = true, INVISIBLE"
+        thrift_propagation: null
+      behavior:
+        "true": "DP join reorder available for medium-sized join graphs"
+        "false": "Falls back to greedy for all non-exhaustive cases"
+      related_variables:
+        - "cbo_max_reorder_node_use_dp"
+        - "cbo_enable_greedy_join_reorder"
+
+    - name: "cbo_max_reorder_node_use_dp"
+      type: Long
+      default: 10
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of join nodes for DP-based join reorder. Beyond this, greedy is used.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 409
+            context: "constant CBO_MAX_REORDER_NODE_USE_DP"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1720
+            context: "@VarAttr field cboMaxReorderNodeUseDP = 10"
+        thrift_propagation: null
+
+    - name: "cbo_enable_greedy_join_reorder"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables greedy join reorder algorithm. Used as fallback for large join graphs.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 410
+            context: "constant CBO_ENABLE_GREEDY_JOIN_REORDER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1726
+            context: "@VarAttr field cboEnableGreedyJoinReorder = true, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "cbo_max_reorder_node_use_greedy"
+      type: Long
+      default: 16
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of join nodes for greedy join reorder.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 411
+            context: "constant CBO_MAX_REORDER_NODE_USE_GREEDY"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1723
+            context: "@VarAttr field cboMaxReorderNodeUseGreedy = 16"
+        thrift_propagation: null
+
+    - name: "cbo_max_reorder_node"
+      type: Integer
+      default: 50
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Absolute maximum number of join nodes considered for any reorder algorithm.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 436
+            context: "constant CBO_MAX_REORDER_NODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1714
+            context: "@VarAttr field cboMaxReorderNode = 50, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "disable_join_reorder"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Completely disables join reorder in the optimizer. When enabled, joins are
+        executed in the order written in the SQL statement. Useful for debugging.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 354
+            context: "constant DISABLE_JOIN_REORDER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1687
+            context: "@VarAttr field disableJoinReorder = false"
+        thrift_propagation: null
+      behavior:
+        "true": "Joins execute in SQL-written order; no optimization"
+        "false": "Optimizer freely reorders joins for best plan"
+
+    - name: "enable_outer_join_reorder"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Allows the optimizer to reorder outer joins. Outer join reorder is more
+        complex than inner join reorder due to null-preserving semantics.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 835
+            context: "constant ENABLE_OUTER_JOIN_REORDER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2809
+            context: "@VarAttr field enableOuterJoinReorder = true"
+        thrift_propagation: null
+
+  cbo_estimation:
+
+    - name: "cbo_use_correlated_join_estimate"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables correlated join cardinality estimation. When enabled, the optimizer
+        accounts for correlation between join predicates when estimating result sizes.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 413
+            context: "constant CBO_USE_CORRELATED_JOIN_ESTIMATE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1401
+            context: "@VarAttr field useCorrelatedJoinEstimate = true, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "cbo_use_correlated_predicate_estimate"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables correlated predicate cardinality estimation. Accounts for correlation
+        between multiple filter predicates.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 414
+            context: "constant CBO_USE_CORRELATED_PREDICATE_ESTIMATE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1404
+            context: "@VarAttr field useCorrelatedPredicateEstimate = true"
+        thrift_propagation: null
+
+    - name: "cbo_enable_histogram_join_estimation"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Uses histogram statistics for more accurate join cardinality estimation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 443
+            context: "constant CBO_ENABLE_HISTOGRAM_JOIN_ESTIMATION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1990
+            context: "@VarAttr field cboEnableHistogramJoinEstimation = true, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "cbo_use_histogram_evaluate_list_partition"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Uses histogram statistics to evaluate list partition pruning.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 461
+            context: "constant CBO_USE_HISTOGRAM_EVALUDATE_LIST_PARTITION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1444
+            context: "@VarAttr field cboUseHistogramEvaluateListPartition = false, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "enable_partition_level_cardinality_estimation"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables partition-level cardinality estimation instead of table-level estimates.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 464
+            context: "constant ENABLE_PARTITION_LEVEL_CARDINALITY_ESTIMATION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1790
+            context: "@VarAttr field, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "select_ratio_threshold"
+      type: Double
+      default: 0.15
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Selectivity ratio threshold used by the optimizer to decide predicate ordering
+        and optimization strategies. Predicates estimated below this ratio are considered
+        highly selective.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 910
+            context: "constant SELECT_RATIO_THRESHOLD"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2884
+            context: "@VarAttr field selectRatioThreshold = 0.15, INVISIBLE"
+        thrift_propagation: null
+
+  cbo_aggregate:
+
+    - name: "cbo_push_down_aggregate_mode"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Controls aggregate pushdown strategy. 0 = auto (optimizer decides), -1 = disable,
+        other values select specific pushdown modes.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 438
+            context: "constant CBO_PUSH_DOWN_AGGREGATE_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1964
+            context: "@VarAttr field cboPushDownAggregateMode = 0, alias/show versioned, INVISIBLE"
+        thrift_propagation: null
+      behavior:
+        "0": "Auto mode — optimizer decides aggregate pushdown"
+        "-1": "Aggregate pushdown disabled"
+
+    - name: "cbo_push_down_aggregate"
+      type: String
+      default: "global"
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        String-based aggregate pushdown control. Values: global, local, none.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 453
+            context: "constant CBO_PUSH_DOWN_AGGREGATE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1978
+            context: "@VarAttr field cboPushDownAggregate = 'global', INVISIBLE"
+        thrift_propagation: null
+
+    - name: "cbo_push_down_aggregate_on_broadcast_join"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Allows pushing aggregate below broadcast join when the broadcast table is small.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 439
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1968
+        thrift_propagation: null
+      related_variables:
+        - "cbo_push_down_aggregate_on_broadcast_join_row_count_limit"
+
+    - name: "cbo_push_down_aggregate_on_broadcast_join_row_count_limit"
+      type: Long
+      default: 250000
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Row count limit for pushing aggregate below broadcast join.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 440
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1971
+        thrift_propagation: null
+
+    - name: "cbo_push_down_groupingset"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables pushing down grouping set operations.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 454
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1981
+        thrift_propagation: null
+
+    - name: "cbo_push_down_groupingset_reshuffle"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables reshuffling when pushing down grouping sets.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 455
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1984
+        thrift_propagation: null
+
+    - name: "cbo_push_down_aggregate_with_multi_column_stats"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables aggregate pushdown using multi-column statistics.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 460
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1987
+        thrift_propagation: null
+
+    - name: "cbo_enable_single_node_prefer_two_stage_aggregate"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        On single-node deployments, prefer two-stage aggregation over one-stage.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 444
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1993
+        thrift_propagation: null
+
+    - name: "cbo_push_down_distinct_below_window"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pushing DISTINCT below window function operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 452
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2860
+        thrift_propagation: null
+
+    - name: "cbo_push_down_distinct"
+      type: String
+      default: "global"
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Controls distinct pushdown strategy. Values: global, local, none.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1059
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2158
+        thrift_propagation: null
+
+    - name: "cbo_push_down_topn_limit"
+      type: Long
+      default: 1000
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum LIMIT value for pushing TopN below joins or other operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 944
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2082
+        thrift_propagation: null
+
+    - name: "cbo_push_down_distinct_limit"
+      type: Long
+      default: 4096
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum LIMIT value for pushing DISTINCT below other operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 946
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2085
+        thrift_propagation: null
+
+    - name: "new_planner_agg_stage"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Forces a specific aggregation stage. 0 = auto, 1 = one stage, 2 = two stage,
+        3 = three stage, 4 = four stage.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 387
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1803
+        thrift_propagation: null
+      behavior:
+        "0": "Auto — optimizer chooses optimal aggregation staging"
+        "1-4": "Forces specific aggregation stage count"
+
+    - name: "enable_cost_based_multi_stage_agg"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Uses cost-based optimization to decide multi-stage aggregation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 388
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1806
+        thrift_propagation: null
+
+    - name: "enable_eliminate_agg"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Allows the optimizer to eliminate unnecessary aggregation operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 258
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1659
+        thrift_propagation: null
+
+    - name: "enable_distinct_column_bucketization"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables distinct column bucketization for more efficient distinct aggregation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 885
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2848
+        thrift_propagation: null
+
+    - name: "enable_group_by_compressed_key"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables compressed key optimization for GROUP BY operations.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 365
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1702
+        thrift_propagation: null
+
+  cbo_cte:
+
+    - name: "cbo_cte_reuse"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables Common Table Expression (CTE) reuse optimization. When enabled, the
+        optimizer materializes CTEs referenced multiple times.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 427
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1410
+        thrift_propagation: null
+      related_variables:
+        - "cbo_cte_reuse_rate"
+        - "cbo_cte_max_limit"
+
+    - name: "cbo_cte_reuse_rate"
+      type: Double
+      default: 1.15
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Cost ratio threshold for CTE reuse. A CTE is reused when the ratio of
+        re-computation cost to materialization cost exceeds this value.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 428
+            context: "constant CBO_CTE_REUSE_RATE (alias)"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1414
+            context: "@VarAttr name=CBO_CTE_REUSE_RATE_V2, alias=CBO_CTE_REUSE_RATE"
+        thrift_propagation: null
+
+    - name: "cbo_cte_max_limit"
+      type: Integer
+      default: 10
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of CTEs that can be reused in a single query.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 429
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1418
+        thrift_propagation: null
+
+    - name: "cbo_cte_force_reuse_node_count"
+      type: Integer
+      default: 2000
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        If a CTE subtree has more than this many nodes, force CTE reuse regardless
+        of the reuse rate threshold.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 432
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1423
+        thrift_propagation: null
+
+    - name: "cbo_cte_force_reuse_limit_without_order_by"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Force CTE reuse for queries with LIMIT but without ORDER BY.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 433
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1428
+        thrift_propagation: null
+
+  cbo_subfield_pruning:
+
+    - name: "cbo_prune_subfield"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables pruning of struct/map subfields. Only referenced subfields are read.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 457
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1434
+        thrift_propagation: null
+      related_variables:
+        - "cbo_prune_json_subfield"
+        - "enable_prune_complex_types"
+
+    - name: "cbo_prune_json_subfield"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pruning of JSON subfields. Only referenced JSON paths are read.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 458
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1438
+            context: "internal name CBO_PRUNE_JSON_SUBFIELD + '_v2', alias/show = CBO_PRUNE_JSON_SUBFIELD"
+        thrift_propagation: null
+
+    - name: "cbo_prune_json_subfield_depth"
+      type: Integer
+      default: 20
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum depth for JSON subfield pruning.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 459
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1441
+        thrift_propagation: null
+
+    - name: "cbo_prune_shuffle_column_rate"
+      type: Double
+      default: 0.1
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Rate threshold for pruning shuffle columns in data redistribution.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 437
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1960
+        thrift_propagation: null
+
+    - name: "cbo_enable_predicate_subfield_path"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables subfield path extraction from predicates for pruning.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 472
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2956
+        thrift_propagation: null
+
+    - name: "enable_prune_complex_types"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pruning of complex types (STRUCT, MAP, ARRAY) to only read used fields.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 843
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2817
+        thrift_propagation: null
+
+    - name: "enable_prune_complex_types_in_unnest"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pruning of complex types inside UNNEST operations.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 845
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2823
+        thrift_propagation: null
+
+    - name: "enable_subfield_no_copy"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables zero-copy subfield access for struct/map types.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 844
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2820
+        thrift_propagation: null
+
+  rewrite_rules:
+
+    - name: "enable_rewrite_simple_agg_to_meta_scan"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Rewrites simple MIN/MAX/COUNT aggregations on OLAP tables to read from tablet
+        metadata (zone maps) instead of scanning data. Dramatically speeds up full-table
+        aggregates with no GROUP BY or WHERE.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 839
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2047
+        thrift_propagation: null
+      behavior:
+        "true": "MIN/MAX/COUNT answered from metadata in milliseconds"
+        "false": "Full table scan to compute aggregates"
+      related_variables:
+        - "enable_rewrite_simple_agg_to_hdfs_scan"
+
+    - name: "enable_rewrite_simple_agg_to_hdfs_scan"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Rewrites simple MIN/MAX/COUNT aggregations on external (HDFS/S3) tables to
+        use file metadata instead of full scans.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 840
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2053
+        thrift_propagation: null
+
+    - name: "enable_rewrite_sum_by_associative_rule"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables rewriting SUM expressions using the associative rule for optimization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 838
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2044
+        thrift_propagation: null
+
+    - name: "enable_rewrite_partition_column_minmax"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Rewrites MIN/MAX on partition columns to use partition metadata.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 841
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2050
+        thrift_propagation: null
+
+    - name: "enable_rewrite_bitmap_union_to_bitamp_agg"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Rewrites bitmap_union to bitmap_agg for better performance. Note: SQL name
+        contains a typo ('bitamp' instead of 'bitmap').
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 983
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2355
+        thrift_propagation: null
+
+    - name: "enable_rewrite_unnest_bitmap_to_array"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Rewrites UNNEST on bitmap columns to use array-based implementation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1036
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3339
+        thrift_propagation: null
+
+    - name: "enable_rewrite_groupingsets_to_union_all"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Rewrites GROUPING SETS queries to UNION ALL for potential parallelism gains.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 462
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1787
+        thrift_propagation: null
+
+    - name: "cbo_rewrite_monotonic_minmax_aggregation"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Rewrites monotonic function MIN/MAX aggregations to leverage ordering.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 474
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2959
+        thrift_propagation: null
+
+    - name: "enable_count_distinct_rewrite_by_hll_bitmap"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Rewrites COUNT(DISTINCT) to use HLL/Bitmap pre-aggregated columns when available.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 938
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2109
+        thrift_propagation: null
+
+    - name: "enable_min_max_optimization"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables min/max optimization for scan operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 842
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2896
+        thrift_propagation: null
+
+    - name: "enable_count_star_optimization"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables COUNT(*) optimization using metadata instead of full scan.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 916
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2893
+        thrift_propagation: null
+
+  predicate_optimization:
+
+    - name: "enable_predicate_reorder"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables reordering predicates by estimated selectivity for more efficient filtering.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 357
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1690
+        thrift_propagation: null
+
+    - name: "enable_predicate_move_around"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables moving predicates between operators for better pushdown.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 985
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3096
+        thrift_propagation: null
+
+    - name: "enable_predicate_expr_reuse"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables reuse of computed predicate expressions across operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1039
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2118
+        thrift_propagation: null
+
+    - name: "enable_pushdown_or_predicate"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables pushing OR predicates down to scan operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 906
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2875
+        thrift_propagation: null
+      related_variables:
+        - "max_pushdown_or_predicates"
+
+    - name: "max_pushdown_or_predicates"
+      type: Integer
+      default: 32
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of OR predicates that can be pushed down.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 908
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2881
+        thrift_propagation: null
+
+    - name: "push_down_heavy_exprs"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pushing computationally expensive expressions down to scan operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1083
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2289
+        thrift_propagation: null
+
+    - name: "enable_fine_grained_range_predicate"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables fine-grained range predicate derivation for better partition pruning.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 717
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3078
+        thrift_propagation: null
+
+    - name: "cbo_derive_range_join_predicate"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Derives range predicates from join conditions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 968
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3075
+        thrift_propagation: null
+
+    - name: "cbo_derive_join_is_null_predicate"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Derives IS NULL predicates from join conditions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 970
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3081
+        thrift_propagation: null
+
+  pushdown_and_pruning:
+
+    - name: "enable_filter_unused_columns_in_scan_stage"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Filters unused columns at scan stage to reduce data transfer.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 359
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1693
+        thrift_propagation: null
+
+    - name: "enable_prune_column_after_index_filter"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Prunes columns after index filter application for reduced I/O.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 367
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1705
+        thrift_propagation: null
+
+    - name: "enable_push_down_pre_agg_with_rank"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pushing pre-aggregation below rank window functions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1032
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3117
+        thrift_propagation: null
+
+    - name: "enable_multi_cast_limit_push_down"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables pushing LIMIT through multi-cast (UNION) operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1069
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2199
+        thrift_propagation: null
+
+    - name: "enable_defer_project_after_topn"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Defers projection until after TopN to reduce data movement in sort.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1067
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2182
+        thrift_propagation: null
+
+    - name: "topn_push_down_agg_mode"
+      type: Integer
+      default: 1
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Controls TopN pushdown through aggregation operators. 0 = disabled, 1 = enabled.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1088
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2297
+        thrift_propagation: null
+
+    - name: "enable_expr_prune_partition"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables expression-based partition pruning.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 950
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2913
+        thrift_propagation: null
+
+    - name: "range_pruner_max_predicate"
+      type: Integer
+      default: 100
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of predicates the range pruner will process.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 846
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2826
+        thrift_propagation: null
+
+  table_prune:
+
+    - name: "enable_rbo_table_prune"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables rule-based table pruning. Removes tables from joins when they
+        contribute no columns to the output and have FK-PK relationships.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 246
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1638
+        thrift_propagation: null
+      related_variables:
+        - "enable_cbo_table_prune"
+        - "enable_ukfk_opt"
+
+    - name: "enable_cbo_table_prune"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables cost-based table pruning.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 249
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1641
+        thrift_propagation: null
+
+    - name: "enable_table_prune_on_update"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables table pruning during UPDATE statements.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 252
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1644
+        thrift_propagation: null
+
+    - name: "enable_ukfk_opt"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables unique key / foreign key optimization for join elimination and table pruning.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 254
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1647
+        thrift_propagation: null
+
+  json_optimization:
+
+    - name: "cbo_json_v2_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables JSON v2 rewrite optimization for JSON operations.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 447
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1453
+        thrift_propagation: null
+
+    - name: "cbo_json_v2_dict_opt"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables dictionary optimization for JSON v2.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 448
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1456
+        thrift_propagation: null
+
+  low_cardinality:
+
+    - name: "cbo_enable_low_cardinality_optimize"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables low cardinality optimization (global dictionary encoding). Strings with
+        low cardinality are encoded as integers for faster processing.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 417
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1763
+        thrift_propagation: null
+      related_variables:
+        - "cbo_enable_low_cardinality_optimize_for_join"
+
+  misc_optimizer:
+
+    - name: "new_planner_optimize_timeout"
+      type: Long
+      default: 3000
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Optimizer timeout in milliseconds. If the optimizer cannot find a plan within
+        this time, it returns the best plan found so far.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 392
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1744
+        thrift_propagation: null
+
+    - name: "cbo_use_nth_exec_plan"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Forces the optimizer to use the Nth execution plan instead of the best one.
+        0 = use best plan. Useful for debugging optimizer choices.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 426
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1407
+        thrift_propagation: null
+
+    - name: "cbo_disabled_rules"
+      type: String
+      default: ""
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Comma-separated list of optimizer rule names to disable. Useful for debugging
+        specific optimization rules.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 450
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1278
+        thrift_propagation: null
+
+    - name: "cbo_debug_alive_backend_number"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Overrides the alive backend count for CBO cost estimation. 0 = use actual count.
+        Useful for reproducible plan testing.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 456
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1729
+        thrift_propagation: null
+
+    - name: "cbo_use_lock_db"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Uses database-level lock during optimization for metadata consistency.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 471
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1450
+        thrift_propagation: null
+
+    - name: "cbo_decimal_cast_string_strict"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables strict decimal-to-string casting in the optimizer.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 972
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3084
+        thrift_propagation: null
+
+    - name: "cbo_eq_base_type"
+      type: String
+      default: "decimal"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Base type used for equality comparisons in CBO. Values: decimal, double.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 974
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3087
+        thrift_propagation: null
+
+    - name: "enable_plan_validation"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables plan validation checks after optimization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 892
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2863
+        thrift_propagation: null
+
+    - name: "enable_short_circuit"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables short-circuit evaluation for point queries on primary key tables.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 976
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2936
+        thrift_propagation: null
+
+    - name: "enable_simplify_case_when"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables CASE WHEN simplification in the optimizer.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 914
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2890
+        thrift_propagation: null
+
+    - name: "disable_function_fold_constants"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Disables constant folding for functions. When true, constant expressions are
+        not evaluated at plan time.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 912
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2887
+        thrift_propagation: null
+
+    - name: "enable_partition_column_value_only_optimization"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Optimizes scan of partition column values from metadata.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 918
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2902
+        thrift_propagation: null
+
+    - name: "enable_evaluate_schema_scan_rule"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables schema scan evaluation rule for information_schema queries.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 847
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2056
+        thrift_propagation: null
+
+    - name: "enable_array_distinct_after_agg_opt"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables optimization of array_distinct after aggregation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 759
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3152
+        thrift_propagation: null
+
+    - name: "cbo_prepare_metadata_thread_pool_size"
+      type: Integer
+      default: 16
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Thread pool size for parallel metadata preparation in the optimizer.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 473
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2965
+        thrift_propagation: null
+
+    - name: "enable_parallel_prepare_metadata"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables parallel metadata preparation during optimization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 476
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2968
+        thrift_propagation: null
+
+    - name: "cbo_enable_intersect_add_distinct"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Adds DISTINCT to INTERSECT operations for optimization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 442
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1974
+        thrift_propagation: null
+
+  be_configs:
+
+    - name: "predicate_sampling_trigger_selectivity_threshold"
+      type: Double
+      default: 0.2
+      scope: "BE config"
+      mutable: true
+      description: >
+        Selectivity threshold that triggers predicate sampling in segment iteration.
+        When predicate selectivity falls below this ratio, sampling-based optimization
+        strategies may be activated.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1923
+            context: "CONF_mDouble(predicate_sampling_trigger_selectivity_threshold, \"0.2\")"
+        thrift_propagation: null

--- a/param-docs/02_join_optimization.yml
+++ b/param-docs/02_join_optimization.yml
@@ -1,0 +1,953 @@
+# StarRocks Parameter Dictionary - Join Optimization
+# Hash join, broadcast, shuffle, runtime filter, skew join, colocate join
+
+join_optimization:
+
+  join_type_control:
+
+    - name: "join_implementation_mode"
+      type: String
+      default: "auto"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls which join implementation the optimizer may choose. Values: auto (optimizer
+        decides), merge, hash, nestloop. Internal name is join_implementation_mode_v2 with
+        alias to join_implementation_mode.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 610
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1928
+        thrift_propagation: null
+
+    - name: "disable_colocate_join"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Disables colocate join optimization. When false (default), the optimizer may use
+        colocate join when tables are co-partitioned on the same BEs, avoiding shuffle.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 222
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1396
+        thrift_propagation: null
+      behavior:
+        "true": "Colocate join disabled; data must be shuffled for joins"
+        "false": "Colocate join enabled when tables are co-partitioned"
+
+    - name: "enable_partition_hash_join"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables partition-wise hash join. When tables are partitioned on join keys,
+        join is performed partition by partition to reduce memory usage.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 363
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1699
+        thrift_propagation: null
+
+    - name: "enable_cross_join"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Allows the optimizer to generate cross join plans. Disabling forces an error
+        when queries would require a cross join.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 960
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2927
+        thrift_propagation: null
+
+    - name: "enable_nested_loop_join"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Allows the optimizer to use nested loop join for non-equi joins.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 962
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2930
+        thrift_propagation: null
+
+    - name: "cross_join_cost_penalty"
+      type: Long
+      default: 1000000
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Cost penalty multiplier for cross joins. Higher values make the optimizer
+        more reluctant to choose cross join plans.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 966
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2962
+        thrift_propagation: null
+
+    - name: "enable_inner_join_to_semi"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Converts inner joins to semi joins when possible for better performance.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1055
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2146
+        thrift_propagation: null
+
+    - name: "semi_join_deduplicat_mode"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls semi-join deduplication strategy. Note: SQL name contains a typo
+        ('deduplicat' instead of 'deduplicate').
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1054
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2143
+        thrift_propagation: null
+
+  broadcast_join:
+
+    - name: "broadcast_row_limit"
+      type: Long
+      default: 15000000
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum row count for the right table in a broadcast join. If the right table
+        has more rows, the optimizer prefers shuffle join instead.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 389
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1738
+        thrift_propagation: null
+      related_variables:
+        - "broadcast_right_table_scale_factor"
+
+    - name: "broadcast_right_table_scale_factor"
+      type: Double
+      default: 10.0
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Scale factor comparing right table size to left table size for broadcast join
+        decision. If right/left ratio exceeds this, shuffle is preferred.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 390
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1741
+        thrift_propagation: null
+
+  hash_join_execution:
+
+    - name: "hash_join_push_down_right_table"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pushing down predicates to the right table in hash join.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 351
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1684
+        thrift_propagation: null
+
+    - name: "enable_hash_join_range_direct_mapping_opt"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables range-based direct mapping optimization in hash join for integer keys.
+        Uses direct array indexing instead of hash lookup when the key range is small.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 518
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1874
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 162 in TQueryOptions"
+
+    - name: "enable_hash_join_linear_chained_opt"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables linear chaining optimization for hash join hash table. Uses a more
+        cache-friendly linear probing strategy.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 519
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1877
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 163 in TQueryOptions"
+
+    - name: "enable_hash_join_serialize_fixed_size_string"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables fixed-size string serialization optimization in hash join to avoid
+        variable-length overhead.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 520
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1880
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 164 in TQueryOptions"
+
+    - name: "hash_join_interpolate_passthrough"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables interpolation passthrough mode in hash join. When enabled, matching
+        rows pass through directly without buffering.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 625
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1945
+        thrift_propagation: null
+
+    - name: "spill_hash_join_probe_op_max_bytes"
+      type: Long
+      default: 2147483648
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum bytes for hash join probe operator before spilling to disk.
+        Default is 2GB. Part of the spill options sent to BE.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 244
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1635
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 25 in TSpillOptions"
+
+  runtime_filter:
+
+    - name: "enable_global_runtime_filter"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables global runtime filter generation. When enabled, the optimizer generates
+        bloom filters from the build side of hash joins that are sent to scan operators
+        on other BEs to skip non-matching data.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 502
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1840
+        thrift_propagation: null
+      behavior:
+        "true": "Global runtime filters generated and distributed across BEs"
+        "false": "No global runtime filters; only local filters within a single BE"
+      related_variables:
+        - "global_runtime_filter_build_max_size"
+        - "global_runtime_filter_wait_timeout"
+        - "runtime_join_filter_push_down_limit"
+
+    - name: "runtime_join_filter_push_down_limit"
+      type: Long
+      default: 1024000
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of rows in the build table for runtime join filter pushdown.
+        If build table exceeds this, runtime filter is not pushed down to storage.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 501
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1837
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 51 in TQueryOptions"
+
+    - name: "global_runtime_filter_build_max_size"
+      type: Long
+      default: 67108864
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum size (bytes) of a single global runtime filter. Default is 64MB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 503
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1852
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 107 in TQueryOptions"
+
+    - name: "global_runtime_filter_build_min_size"
+      type: Long
+      default: 131072
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Minimum size (bytes) of a global runtime filter. Default is 128KB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 505
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1855
+        thrift_propagation: null
+
+    - name: "global_runtime_filter_probe_min_size"
+      type: Long
+      default: 102400
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Minimum probe-side size (bytes) to use a global runtime filter. Default ~100KB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 506
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1857
+        thrift_propagation: null
+
+    - name: "global_runtime_filter_probe_min_selectivity"
+      type: Float
+      default: 0.5
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Minimum expected selectivity for runtime filter to be worthwhile.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 507
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1859
+        thrift_propagation: null
+
+    - name: "global_runtime_filter_wait_timeout"
+      type: Integer
+      default: 20
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum time (ms) a scan operator waits for runtime filter to arrive before
+        proceeding without it.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 509
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1861
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 52 in TQueryOptions (runtime_filter_wait_timeout_ms)"
+
+    - name: "global_runtime_filter_rpc_timeout"
+      type: Integer
+      default: 400
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Timeout (ms) for sending runtime filters between BEs.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 510
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1863
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 53 in TQueryOptions (runtime_filter_send_timeout_ms)"
+
+    - name: "runtime_filter_early_return_selectivity"
+      type: Float
+      default: 0.05
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        If runtime filter selectivity is below this threshold, scan returns early
+        (stops applying the filter as it's too selective to be efficient).
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 511
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1865
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 88 in TQueryOptions"
+
+    - name: "enable_topn_runtime_filter"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables TopN-based runtime filter. Generates a runtime filter from TopN results
+        to prune scan data early.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 512
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1843
+        thrift_propagation: null
+
+    - name: "global_runtime_filter_rpc_http_min_size"
+      type: Long
+      default: 67108864
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Minimum runtime filter size (bytes) before using HTTP instead of RPC for transfer.
+        Default is 64MB. Larger filters use HTTP for better reliability.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 514
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1867
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 108 in TQueryOptions"
+
+    - name: "enable_join_runtime_filter_push_down"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables pushing runtime filters down to the storage layer for predicate evaluation
+        during scan.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 515
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1869
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 160 in TQueryOptions"
+
+    - name: "enable_join_runtime_bitset_filter"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables bitset-based runtime filter in addition to bloom filters. Bitset filters
+        are exact (no false positives) but require enumerable key spaces.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 516
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1871
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 161 in TQueryOptions"
+
+    - name: "runtime_filter_scan_wait_time"
+      type: Long
+      default: 20
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Time (ms) scan operator waits for runtime filter before starting scan.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 599
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1192
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 57 in TQueryOptions (runtime_filter_scan_wait_time_ms)"
+
+    - name: "runtime_filter_on_exchange_node"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Applies runtime filter on exchange nodes in addition to scan nodes.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 600
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1195
+        thrift_propagation: null
+
+    - name: "enable_multicolumn_global_runtime_filter"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables multi-column global runtime filters for composite join keys.
+        Internal name is _v2 with alias to the base name.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 601
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1198
+        thrift_propagation: null
+
+    - name: "enable_pipeline_level_multi_partitioned_rf"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pipeline-level multi-partitioned runtime filter for better locality.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 522
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1883
+        thrift_propagation: null
+
+  skew_join:
+
+    - name: "enable_optimize_skew_join_v1"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables skew join optimization v1 via query rewrite. Detects data skew and
+        rewrites the join to handle skewed keys separately.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 466
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1793
+        thrift_propagation: null
+      related_variables:
+        - "enable_optimize_skew_join_v2"
+        - "enable_stats_to_optimize_skew_join"
+
+    - name: "enable_optimize_skew_join_v2"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables skew join optimization v2 by broadcasting skewed values. More aggressive
+        than v1 but uses more memory.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 468
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1796
+        thrift_propagation: null
+
+    - name: "enable_stats_to_optimize_skew_join"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Uses column statistics (MCV - Most Common Values) to identify and optimize
+        skewed join keys.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 479
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3054
+        thrift_propagation: null
+
+    - name: "skew_join_rand_range"
+      type: Integer
+      default: 1000
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Random range for skew join salt values.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 478
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3052
+        thrift_propagation: null
+
+    - name: "skew_join_use_mcv_count"
+      type: Integer
+      default: 5
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Number of Most Common Values to use for skew join optimization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 480
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3058
+        thrift_propagation: null
+
+    - name: "skew_join_data_skew_threshold"
+      type: Double
+      default: 0.2
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Threshold ratio for detecting data skew in join keys.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 481
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3061
+        thrift_propagation: null
+
+    - name: "skew_join_mcv_single_threshold"
+      type: Double
+      default: 0.1
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Threshold for a single MCV value's proportion to be considered skewed.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 482
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3065
+        thrift_propagation: null
+
+    - name: "skew_join_mcv_min_input_rows"
+      type: Long
+      default: 10000000
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Minimum input rows before skew join optimization is considered.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 483
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3069
+        thrift_propagation: null
+
+  ukfk_join:
+
+    - name: "enable_ukfk_join_reorder"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables join reorder using unique key / foreign key constraints. Can produce
+        better plans for star schema queries.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 255
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1650
+        thrift_propagation: null
+
+    - name: "max_ukfk_join_reorder_scale_ratio"
+      type: Integer
+      default: 100
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum scale ratio between UK and FK tables for UKFK join reorder.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 256
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1653
+        thrift_propagation: null
+
+    - name: "max_ukfk_join_reorder_fk_rows"
+      type: Integer
+      default: 100000000
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum FK table row count for UKFK join reorder.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 257
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1656
+        thrift_propagation: null
+
+    - name: "enable_join_reorder_before_deduplicate"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Allows join reorder before deduplication in certain query patterns.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1056
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2152
+        thrift_propagation: null
+
+    - name: "join_reorder_driving_table_max_element"
+      type: Integer
+      default: 5
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum elements in the driving table for join reorder selection.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1057
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2149
+        thrift_propagation: null
+
+  shuffle:
+
+    - name: "enable_pipeline_level_shuffle"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables pipeline-level data shuffle for better data locality within the
+        execution pipeline.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 711
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3318
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 112 in TQueryOptions"
+
+  be_configs:
+
+    - name: "deliver_broadcast_rf_passthrough_bytes_limit"
+      type: Long
+      default: 131072
+      scope: "BE config"
+      mutable: false
+      description: >
+        If runtime filter from broadcast join is below this size (bytes), it is delivered
+        in passthrough style (direct copy). Otherwise, it is relayed through another BE.
+        Default is 128KB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1185
+            context: "CONF_Int64(deliver_broadcast_rf_passthrough_bytes_limit, \"131072\")"
+        thrift_propagation: null
+
+    - name: "deliver_broadcast_rf_passthrough_inflight_num"
+      type: Long
+      default: 10
+      scope: "BE config"
+      mutable: false
+      description: >
+        Maximum number of in-flight passthrough runtime filter deliveries.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1187
+            context: "CONF_Int64(deliver_broadcast_rf_passthrough_inflight_num, \"10\")"
+        thrift_propagation: null
+
+    - name: "send_rpc_runtime_filter_timeout_ms"
+      type: Long
+      default: 1000
+      scope: "BE config"
+      mutable: false
+      description: >
+        RPC timeout (ms) for sending runtime filters between BEs.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1188
+            context: "CONF_Int64(send_rpc_runtime_filter_timeout_ms, \"1000\")"
+        thrift_propagation: null
+
+    - name: "send_runtime_filter_via_http_rpc_min_size"
+      type: Long
+      default: 67108864
+      scope: "BE config"
+      mutable: false
+      description: >
+        Minimum runtime filter size (bytes) to use HTTP instead of RPC for transmission.
+        Default is 64MB. May be overridden by the session variable
+        global_runtime_filter_rpc_http_min_size.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1191
+            context: "CONF_Int64(send_runtime_filter_via_http_rpc_min_size, \"67108864\")"
+        thrift_propagation: null
+      related_variables:
+        - "global_runtime_filter_rpc_http_min_size (session variable)"
+
+    - name: "runtime_filter_queue_limit"
+      type: Long
+      default: -1
+      scope: "BE config"
+      mutable: true
+      description: >
+        Limit on runtime filter queue size. -1 = unlimited.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1194
+            context: "CONF_mInt64(runtime_filter_queue_limit, \"-1\")"
+        thrift_propagation: null
+
+    - name: "partition_hash_join_probe_limit_size"
+      type: Long
+      default: 134217728
+      scope: "BE config"
+      mutable: true
+      description: >
+        Memory limit (bytes) for partition hash join probe side buffer. Default is 128MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1574
+            context: "CONF_mInt64(partition_hash_join_probe_limit_size, \"134217728\")"
+        thrift_propagation: null
+
+    - name: "rf_sample_rows"
+      type: Long
+      default: 1024
+      scope: "BE config"
+      mutable: true
+      description: >
+        Number of sample rows for runtime filter pushdown execution strategy.
+        Internal tuning parameter.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1883
+            context: "CONF_mInt64(rf_sample_rows, \"1024\")"
+        thrift_propagation: null
+
+    - name: "rf_sample_ratio"
+      type: Long
+      default: 32
+      scope: "BE config"
+      mutable: true
+      description: >
+        Sampling ratio for runtime filter pushdown. Internal tuning parameter.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1884
+            context: "CONF_mInt64(rf_sample_ratio, \"32\")"
+        thrift_propagation: null
+
+    - name: "rf_branchless_ratio"
+      type: Long
+      default: 8
+      scope: "BE config"
+      mutable: true
+      description: >
+        Branchless evaluation ratio for runtime filter. Internal tuning parameter.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1885
+            context: "CONF_mInt64(rf_branchless_ratio, \"8\")"
+        thrift_propagation: null

--- a/param-docs/03_scan_and_io.yml
+++ b/param-docs/03_scan_and_io.yml
@@ -1,0 +1,1127 @@
+# StarRocks Parameter Dictionary - Scan and I/O
+# Scan limits, split sizes, data cache, page cache
+
+scan_and_io:
+
+  scan_session_variables:
+
+    - name: "chunk_size"
+      type: Integer
+      default: 4096
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Number of rows per chunk for vectorized execution. Controls the batch size for
+        scan and processing operators. Larger values improve throughput but use more memory.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 220
+            context: "constant CHUNK_SIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1389
+            context: "@VarAttr field chunkSize = 4096, INVISIBLE"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6031
+            context: "Field batch_size in TQueryOptions"
+      behavior:
+        low_values: "Smaller batches, less memory per operator, more overhead per batch"
+        high_values: "Larger batches, better vectorization throughput, more memory per operator"
+
+    - name: "max_scan_key_num"
+      type: Integer
+      default: -1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of scan keys (point lookups) to use when converting IN-list
+        predicates to scan ranges. -1 means use the BE default.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 273
+            context: "constant MAX_SCAN_KEY_NUM"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1677
+            context: "@VarAttr field maxScanKeyNum = -1"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6034
+            context: "Field max_scan_key_num in TQueryOptions"
+
+    - name: "max_pushdown_conditions_per_column"
+      type: Integer
+      default: -1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of conditions per column that can be pushed down to the storage
+        layer. -1 means use the BE default.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 274
+            context: "constant MAX_PUSHDOWN_CONDITIONS_PER_COLUMN"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1679
+            context: "@VarAttr field maxPushdownConditionsPerColumn = -1"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6037
+            context: "Field max_pushdown_conditions_per_column in TQueryOptions"
+
+    - name: "enable_tablet_internal_parallel"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables intra-tablet parallelism for OLAP scan. When enabled, a single tablet
+        scan can be split across multiple threads for better scan throughput.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 331
+            context: "constant ENABLE_TABLET_INTERNAL_PARALLEL"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1202
+            context: "@VarAttr field enableTabletInternalParallel = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6120
+            context: "Field enable_tablet_internal_parallel in TQueryOptions"
+      related_variables:
+        - "tablet_internal_parallel_mode"
+        - "enable_lake_tablet_internal_parallel"
+
+    - name: "enable_lake_tablet_internal_parallel"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables intra-tablet parallelism for lake (shared-data) tablet scans.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 333
+            context: "constant ENABLE_LAKE_TABLET_INTERNAL_PARALLEL"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1206
+            context: "@VarAttr field enableLakeTabletInternalParallel = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6121
+            context: "Field enable_lake_tablet_internal_parallel in TQueryOptions"
+
+    - name: "tablet_internal_parallel_mode"
+      type: String
+      default: "auto"
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Controls the mode for tablet internal parallelism. Values: auto (system decides
+        based on data size), force_split (always split).
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 335
+            context: "constant TABLET_INTERNAL_PARALLEL_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1211
+            context: "@VarAttr field tabletInternalParallelMode = 'auto', INVISIBLE"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6126
+            context: "Field tablet_internal_parallel_mode in TQueryOptions"
+
+    - name: "enable_scan_datacache"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      alias: "enable_scan_block_cache"
+      description: >
+        Enables data cache for scan operations. When enabled, scanned data from remote
+        storage is cached locally for subsequent reads.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 646
+            context: "constant ENABLE_SCAN_DATACACHE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2529
+            context: "@VarAttr field enableScanDataCache = true, alias=enable_scan_block_cache"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6134
+            context: "Field enable_scan_datacache in TQueryOptions"
+
+    - name: "enable_populate_datacache"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      alias: "enable_populate_block_cache"
+      description: >
+        Enables populating the data cache during scans. When disabled, scans may read
+        from cache but will not insert new data into it.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 647
+            context: "constant ENABLE_POPULATE_DATACACHE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2532
+            context: "@VarAttr field enablePopulateDataCache = true, INVISIBLE, alias=enable_populate_block_cache"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6135
+            context: "Field enable_populate_datacache in TQueryOptions"
+
+    - name: "populate_datacache_mode"
+      type: String
+      default: "auto"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls when data cache is populated. Values: auto (system decides based on
+        access patterns), always, never.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 648
+            context: "constant POPULATE_DATACACHE_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2535
+            context: "@VarAttr field populateDataCacheMode = 'auto'"
+        thrift_propagation: null
+
+    - name: "enable_datacache_async_populate_mode"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables asynchronous data cache population. Cache writes happen in background
+        threads instead of blocking the scan path.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 649
+            context: "constant ENABLE_DATACACHE_ASYNC_POPULATE_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2549
+            context: "@VarAttr field enableDataCacheAsyncPopulateMode = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6136
+            context: "Field enable_datacache_async_populate_mode in TQueryOptions"
+
+    - name: "enable_datacache_io_adaptor"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables the data cache I/O adaptor for optimized cache read/write paths.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 650
+            context: "constant ENABLE_DATACACHE_IO_ADAPTOR"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2552
+            context: "@VarAttr field enableDataCacheIOAdaptor = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6137
+            context: "Field enable_datacache_io_adaptor in TQueryOptions"
+
+    - name: "datacache_evict_probability"
+      type: Integer
+      default: 100
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Probability (0-100) of evicting a cache entry when the cache is full. Lower values
+        reduce eviction churn but may result in stale data.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 651
+            context: "constant DATACACHE_EVICT_PROBABILITY"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2555
+            context: "@VarAttr field dataCacheEvictProbability = 100, INVISIBLE"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6138
+            context: "Field datacache_evict_probability in TQueryOptions"
+
+    - name: "enable_dynamic_prune_scan_range"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables dynamic pruning of scan ranges at runtime based on runtime filters
+        and partition information.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 663
+            context: "constant ENABLE_DYNAMIC_PRUNE_SCAN_RANGE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2564
+            context: "@VarAttr field enableDynamicPruneScanRange = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6147
+            context: "Field enable_dynamic_prune_scan_range in TQueryOptions"
+
+    - name: "io_tasks_per_scan_operator"
+      type: Integer
+      default: 4
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Number of concurrent I/O tasks per OLAP scan operator instance.
+        Controls scan I/O parallelism for native tables.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 664
+            context: "constant IO_TASKS_PER_SCAN_OPERATOR"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2567
+            context: "@VarAttr field ioTasksPerScanOperator = 4"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6145
+            context: "Field io_tasks_per_scan_operator in TQueryOptions"
+
+    - name: "connector_io_tasks_per_scan_operator"
+      type: Integer
+      default: 16
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Number of concurrent I/O tasks per connector (external table) scan operator.
+        Higher than OLAP default because external storage has higher latency.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 665
+            context: "constant CONNECTOR_IO_TASKS_PER_SCAN_OPERATOR"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2570
+            context: "@VarAttr field connectorIoTasksPerScanOperator = 16"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6146
+            context: "Field connector_io_tasks_per_scan_operator in TQueryOptions"
+
+    - name: "enable_connector_adaptive_io_tasks"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables adaptive I/O task scheduling for connector scans. Dynamically adjusts
+        the number of I/O tasks based on observed latency.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 666
+            context: "constant ENABLE_CONNECTOR_ADAPTIVE_IO_TASKS"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2573
+            context: "@VarAttr field enableConnectorAdaptiveIoTasks = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6150
+            context: "Field enable_connector_adaptive_io_tasks in TQueryOptions"
+      related_variables:
+        - "connector_io_tasks_slow_io_latency_ms"
+
+    - name: "connector_io_tasks_slow_io_latency_ms"
+      type: Integer
+      default: 50
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Latency threshold (ms) for classifying connector I/O as slow. When adaptive I/O
+        tasks is enabled, tasks exceeding this latency trigger increased parallelism.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 667
+            context: "constant CONNECTOR_IO_TASKS_SLOW_IO_LATENCY_MS"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2579
+            context: "@VarAttr field connectorIoTasksSlowIoLatencyMs = 50, INVISIBLE"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6152
+            context: "Field connector_io_tasks_slow_io_latency_ms in TQueryOptions"
+
+    - name: "enable_connector_split_io_tasks"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables splitting large I/O tasks for connector scans into smaller ones for
+        better parallelism and load balancing.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 673
+            context: "constant ENABLE_CONNECTOR_SPLIT_IO_TASKS"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2576
+            context: "@VarAttr field enableConnectorSplitIoTasks = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6151
+            context: "Field enable_connector_split_io_tasks in TQueryOptions"
+
+    - name: "scan_use_query_mem_ratio"
+      type: Double
+      default: 0.3
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Fraction of query memory budget allocated to scan operators for OLAP tables.
+        Controls how much memory scan operators can use relative to the total query memory.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 668
+            context: "constant SCAN_USE_QUERY_MEM_RATIO"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2582
+            context: "@VarAttr field scanUseQueryMemRatio = 0.3"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6154
+            context: "Field scan_use_query_mem_ratio in TQueryOptions"
+
+    - name: "connector_scan_use_query_mem_ratio"
+      type: Double
+      default: 0.3
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Fraction of query memory budget allocated to connector (external table) scan operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 669
+            context: "constant CONNECTOR_SCAN_USE_QUERY_MEM_RATIO"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2585
+            context: "@VarAttr field connectorScanUseQueryMemRatio = 0.3"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6153
+            context: "Field connector_scan_use_query_mem_ratio in TQueryOptions"
+
+    - name: "use_page_cache"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables the storage page cache for scan operations. When true, recently read
+        data pages are cached in memory.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 166
+            context: "constant USE_PAGE_CACHE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1238
+            context: "@VarAttr field usePageCache = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6148
+            context: "Field use_page_cache in TQueryOptions"
+
+    - name: "enable_file_metacache"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables caching of file metadata (e.g., Parquet/ORC footer) to avoid redundant
+        remote reads of file structure information.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 659
+            context: "constant ENABLE_FILE_METACACHE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2610
+            context: "@VarAttr field enableFileMetaCache = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6142
+            context: "Field enable_file_metacache in TQueryOptions"
+
+    - name: "enable_file_pagecache"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables caching of file data pages for external table scans.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 660
+            context: "constant ENABLE_FILE_PAGECACHE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2613
+            context: "@VarAttr field enableFilePageCache = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6143
+            context: "Field enable_file_pagecache in TQueryOptions"
+
+    - name: "connector_max_split_size"
+      type: Long
+      default: 67108864
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum split size (bytes) for connector scans. Default is 64MB. Larger splits
+        reduce scheduling overhead but may limit parallelism.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 999
+            context: "constant CONNECTOR_MAX_SPLIT_SIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2945
+            context: "@VarAttr field connectorMaxSplitSize = 67108864"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6166
+            context: "Field connector_max_split_size in TQueryOptions"
+
+    - name: "scan_or_to_union_limit"
+      type: Integer
+      default: 4
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of OR branches that can be rewritten into a UNION ALL scan.
+        Limits the fan-out of the OR-to-UNION transformation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 902
+            context: "constant SCAN_OR_TO_UNION_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2869
+            context: "@VarAttr field scanOrToUnionLimit = 4, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "scan_or_to_union_threshold"
+
+    - name: "scan_or_to_union_threshold"
+      type: Long
+      default: 50000000
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Row count threshold for the OR-to-UNION transformation. Only applied when
+        estimated row count exceeds this value.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 904
+            context: "constant SCAN_OR_TO_UNION_THRESHOLD"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2872
+            context: "@VarAttr field scanOrToUnionThreshold = 50000000, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "enable_collect_table_level_scan_stats"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables collection of table-level scan statistics during query execution.
+        Used for query profiling and optimization feedback.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 929
+            context: "constant ENABLE_COLLECT_TABLE_LEVEL_SCAN_STATS"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2907
+            context: "@VarAttr field enableCollectTableLevelScanStats = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6158
+            context: "Field enable_collect_table_level_scan_stats in TQueryOptions"
+
+    - name: "enable_hyperscan_vec"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables vectorized Hyperscan library for regex matching in scan predicates.
+        Hyperscan provides SIMD-accelerated regex evaluation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 980
+            context: "constant ENABLE_HYPERSCAN_VEC"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2091
+            context: "@VarAttr field enableHyperscanVec = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6161
+            context: "Field enable_hyperscan_vec in TQueryOptions"
+
+    - name: "enable_connector_incremental_scan_ranges"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables incremental delivery of scan ranges to connector scan operators.
+        Instead of sending all ranges upfront, ranges are delivered in batches.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1020
+            context: "constant ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3105
+            context: "@VarAttr field enableConnectorIncrementalScanRanges = true"
+        thrift_propagation: null
+      related_variables:
+        - "connector_incremental_scan_ranges_size"
+
+    - name: "connector_incremental_scan_ranges_size"
+      type: Integer
+      default: 500
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Batch size for incremental scan range delivery to connector scan operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1021
+            context: "constant CONNECTOR_INCREMENTAL_SCAN_RANGES_SIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3111
+            context: "@VarAttr field connectorIncrementalScanRangesSize = 500"
+        thrift_propagation: null
+
+    - name: "enable_datacache_sharing"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables data cache sharing across queries and sessions. When enabled,
+        cache entries populated by one query can be used by other queries.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1061
+            context: "constant ENABLE_DATACACHE_SHARING"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2161
+            context: "@VarAttr field enableDataCacheSharing = true"
+        thrift_propagation: null
+      related_variables:
+        - "datacache_sharing_work_period"
+
+    - name: "datacache_sharing_work_period"
+      type: Integer
+      default: 600
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Work period (seconds) for data cache sharing coordination. Controls how frequently
+        the cache sharing metadata is refreshed.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1062
+            context: "constant DATACACHE_SHARING_WORK_PERIOD"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2164
+            context: "@VarAttr field dataCacheSharingWorkPeriod = 600"
+        thrift_propagation: null
+
+  scan_be_configs:
+
+    - name: "scanner_thread_pool_thread_num"
+      type: Integer
+      default: 48
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of threads in the scanner thread pool. Controls the maximum concurrent
+        scan operations on a single BE.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_Int32(scanner_thread_pool_thread_num, \"48\")"
+        thrift_propagation: null
+
+    - name: "scanner_row_num"
+      type: Integer
+      default: 16384
+      scope: "BE config"
+      mutable: true
+      description: >
+        Default number of rows returned per scanner read batch.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(scanner_row_num, \"16384\")"
+        thrift_propagation: null
+
+    - name: "max_hdfs_scanner_num"
+      type: Integer
+      default: 50
+      scope: "BE config"
+      mutable: false
+      description: >
+        Maximum number of concurrent HDFS scanners per BE node.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_Int32(max_hdfs_scanner_num, \"50\")"
+        thrift_propagation: null
+
+    - name: "max_scan_key_num"
+      type: Integer
+      default: 1024
+      scope: "BE config"
+      mutable: true
+      description: >
+        BE-side maximum number of scan keys per scan request. Used when the FE session
+        variable max_scan_key_num is -1 (defer to BE default).
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(max_scan_key_num, \"1024\")"
+        thrift_propagation: null
+
+    - name: "max_pushdown_conditions_per_column"
+      type: Integer
+      default: 1024
+      scope: "BE config"
+      mutable: true
+      description: >
+        BE-side maximum pushdown conditions per column. Used when the FE session
+        variable is -1 (defer to BE default).
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(max_pushdown_conditions_per_column, \"1024\")"
+        thrift_propagation: null
+
+    - name: "scan_use_query_mem_ratio"
+      type: Double
+      default: 0.25
+      scope: "BE config"
+      mutable: true
+      description: >
+        BE-side default ratio of query memory allocated to scan operators.
+        May be overridden by the FE session variable.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(scan_use_query_mem_ratio, \"0.25\")"
+        thrift_propagation: null
+
+    - name: "connector_scan_use_query_mem_ratio"
+      type: Double
+      default: 0.3
+      scope: "BE config"
+      mutable: true
+      description: >
+        BE-side default ratio of query memory allocated to connector scan operators.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(connector_scan_use_query_mem_ratio, \"0.3\")"
+        thrift_propagation: null
+
+    - name: "io_tasks_per_scan_operator"
+      type: Integer
+      default: 4
+      scope: "BE config"
+      mutable: true
+      description: >
+        BE-side default I/O tasks per OLAP scan operator.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(io_tasks_per_scan_operator, \"4\")"
+        thrift_propagation: null
+
+    - name: "connector_io_tasks_per_scan_operator"
+      type: Integer
+      default: 16
+      scope: "BE config"
+      mutable: true
+      description: >
+        BE-side default I/O tasks per connector scan operator.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(connector_io_tasks_per_scan_operator, \"16\")"
+        thrift_propagation: null
+
+    - name: "connector_io_tasks_min_size"
+      type: Integer
+      default: 2
+      scope: "BE config"
+      mutable: true
+      description: >
+        Minimum number of I/O tasks for connector scan adaptive scheduling.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(connector_io_tasks_min_size, \"2\")"
+        thrift_propagation: null
+
+    - name: "connector_io_tasks_adjust_interval_ms"
+      type: Integer
+      default: 50
+      scope: "BE config"
+      mutable: true
+      description: >
+        Interval (ms) between adaptive I/O task count adjustments for connector scans.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(connector_io_tasks_adjust_interval_ms, \"50\")"
+        thrift_propagation: null
+
+    - name: "connector_io_tasks_adjust_step"
+      type: Integer
+      default: 1
+      scope: "BE config"
+      mutable: true
+      description: >
+        Step size for adaptive I/O task count adjustments.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(connector_io_tasks_adjust_step, \"1\")"
+        thrift_propagation: null
+
+    - name: "connector_io_tasks_adjust_smooth"
+      type: Double
+      default: 0.2
+      scope: "BE config"
+      mutable: true
+      description: >
+        Smoothing factor for adaptive I/O task adjustments. Controls how aggressively
+        the system responds to latency changes.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(connector_io_tasks_adjust_smooth, \"0.2\")"
+        thrift_propagation: null
+
+    - name: "connector_io_tasks_slow_io_latency_ms"
+      type: Integer
+      default: 50
+      scope: "BE config"
+      mutable: true
+      description: >
+        BE-side slow I/O latency threshold (ms) for connector adaptive scheduling.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(connector_io_tasks_slow_io_latency_ms, \"50\")"
+        thrift_propagation: null
+
+    - name: "tablet_internal_parallel_min_splitted_scan_rows"
+      type: Long
+      default: 16384
+      scope: "BE config"
+      mutable: true
+      description: >
+        Minimum rows per split for tablet internal parallel scan. Avoids creating
+        splits that are too small to benefit from parallelism.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(tablet_internal_parallel_min_splitted_scan_rows, \"16384\")"
+        thrift_propagation: null
+
+    - name: "tablet_internal_parallel_max_splitted_scan_rows"
+      type: Long
+      default: 1048576
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum rows per split for tablet internal parallel scan.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(tablet_internal_parallel_max_splitted_scan_rows, \"1048576\")"
+        thrift_propagation: null
+
+    - name: "tablet_internal_parallel_max_splitted_scan_bytes"
+      type: Long
+      default: 536870912
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum bytes per split for tablet internal parallel scan. Default is 512MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(tablet_internal_parallel_max_splitted_scan_bytes, \"536870912\")"
+        thrift_propagation: null
+
+    - name: "tablet_internal_parallel_min_scan_dop"
+      type: Integer
+      default: 4
+      scope: "BE config"
+      mutable: true
+      description: >
+        Minimum degree of parallelism for tablet internal parallel scan.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(tablet_internal_parallel_min_scan_dop, \"4\")"
+        thrift_propagation: null
+
+  cache_be_configs:
+
+    - name: "datacache_enable"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Master switch for the BE data cache. Must be enabled for any data cache
+        functionality to work on this BE node.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mBool(datacache_enable, \"false\")"
+        thrift_propagation: null
+
+    - name: "datacache_mem_size"
+      type: String
+      default: "10%"
+      scope: "BE config"
+      mutable: false
+      description: >
+        Memory size for data cache. Can be a percentage of total memory (e.g., "10%")
+        or an absolute value (e.g., "10G").
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_String(datacache_mem_size, \"10%\")"
+        thrift_propagation: null
+
+    - name: "datacache_disk_size"
+      type: String
+      default: "0"
+      scope: "BE config"
+      mutable: false
+      description: >
+        Disk size for data cache. 0 disables disk-based caching. Can be an absolute value
+        (e.g., "100G") or percentage of disk.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_String(datacache_disk_size, \"0\")"
+        thrift_propagation: null
+
+    - name: "datacache_block_size"
+      type: Long
+      default: 262144
+      scope: "BE config"
+      mutable: false
+      description: >
+        Block size (bytes) for data cache. Default is 256KB. Smaller blocks allow finer
+        granularity but increase metadata overhead.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_Int64(datacache_block_size, \"262144\")"
+        thrift_propagation: null
+
+    - name: "datacache_eviction_policy"
+      type: String
+      default: "lru"
+      scope: "BE config"
+      mutable: false
+      description: >
+        Eviction policy for data cache. Values: lru (least recently used).
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_String(datacache_eviction_policy, \"lru\")"
+        thrift_propagation: null
+
+    - name: "storage_page_cache_limit"
+      type: String
+      default: "20%"
+      scope: "BE config"
+      mutable: false
+      description: >
+        Memory limit for the storage page cache. Can be percentage of BE memory or
+        absolute value. Controls the cache used for OLAP tablet data pages.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_String(storage_page_cache_limit, \"20%\")"
+        thrift_propagation: null
+
+    - name: "disable_storage_page_cache"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Disables the storage page cache entirely. Useful for memory-constrained
+        environments or when page cache causes memory pressure.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mBool(disable_storage_page_cache, \"false\")"
+        thrift_propagation: null
+
+    - name: "query_cache_capacity"
+      type: Long
+      default: 536870912
+      scope: "BE config"
+      mutable: false
+      description: >
+        Capacity (bytes) of the query result cache. Default is 512MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_Int64(query_cache_capacity, \"536870912\")"
+        thrift_propagation: null
+
+    - name: "enable_bitmap_index_memory_page_cache"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables memory page cache for bitmap index. Caches bitmap index pages to avoid
+        repeated disk reads.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mBool(enable_bitmap_index_memory_page_cache, \"false\")"
+        thrift_propagation: null
+
+    - name: "enable_zonemap_index_memory_page_cache"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables memory page cache for zonemap (min/max) index.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mBool(enable_zonemap_index_memory_page_cache, \"false\")"
+        thrift_propagation: null
+
+    - name: "enable_ordinal_index_memory_page_cache"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables memory page cache for ordinal index.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mBool(enable_ordinal_index_memory_page_cache, \"false\")"
+        thrift_propagation: null
+
+  dictionary_encoding_be_configs:
+
+    - name: "dictionary_encoding_ratio"
+      type: Double
+      default: 0.7
+      scope: "BE config"
+      mutable: true
+      description: >
+        Threshold ratio for applying dictionary encoding to string columns.
+        If the ratio of distinct values to total rows is below this, dictionary encoding
+        is used.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(dictionary_encoding_ratio, \"0.7\")"
+        thrift_propagation: null
+
+    - name: "dictionary_encoding_ratio_for_non_string_column"
+      type: Double
+      default: 0.9
+      scope: "BE config"
+      mutable: true
+      description: >
+        Threshold ratio for applying dictionary encoding to non-string columns.
+        Higher than string threshold since non-string dictionary encoding is more efficient.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(dictionary_encoding_ratio_for_non_string_column, \"0.9\")"
+        thrift_propagation: null
+
+    - name: "dictionary_speculate_min_chunk_size"
+      type: Integer
+      default: 10000
+      scope: "BE config"
+      mutable: true
+      description: >
+        Minimum chunk size for dictionary encoding speculation. Below this size,
+        the system does not speculate on dictionary encoding effectiveness.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(dictionary_speculate_min_chunk_size, \"10000\")"
+        thrift_propagation: null
+
+    - name: "dictionary_page_size"
+      type: Integer
+      default: 1048576
+      scope: "BE config"
+      mutable: false
+      description: >
+        Size (bytes) of dictionary pages in columnar storage. Default is 1MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_Int32(dictionary_page_size, \"1048576\")"
+        thrift_propagation: null

--- a/param-docs/04_parquet_orc_reader.yml
+++ b/param-docs/04_parquet_orc_reader.yml
@@ -1,0 +1,1033 @@
+# StarRocks Parameter Dictionary - Parquet/ORC Reader Settings
+# Auto-generated from codebase analysis
+
+parquet_orc_reader:
+
+  parquet_session_variables:
+
+    - name: "enable_parquet_reader_bloom_filter"
+      type: Boolean
+      default: true
+      scope: "FE session variable + BE config"
+      mutable: true
+      description: >
+        Controls whether the Parquet reader uses bloom filter indexes to skip
+        irrelevant data pages. Gated by BE config parquet_reader_bloom_filter_enable:
+        if the BE config is false, this session variable has no effect.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1040
+            context: "constant ENABLE_PARQUET_READER_BLOOM_FILTER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3264
+            context: "@VarAttr field enableParquetReaderBloomFilter = true"
+        usage:
+          - file: "be/src/connector/hive_connector.cpp"
+            line: 858
+            context: "Two-level gating: BE config AND session variable determine parquet_bloom_filter_enable in scanner_params"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 349
+            context: "Field 170 in TQueryOptions"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 6169
+            context: "tResult.setEnable_parquet_reader_bloom_filter()"
+      behavior:
+        "true": "Parquet reader uses bloom filter indexes to skip pages that cannot contain matching values"
+        "false": "Bloom filter indexes are ignored; all pages in matching row groups are read"
+      related_variables:
+        - "parquet_reader_bloom_filter_enable (BE config)"
+        - "parquet_reader_enable_adpative_bloom_filter (BE config)"
+
+    - name: "enable_parquet_reader_page_index"
+      type: Boolean
+      default: true
+      scope: "FE session variable + BE config"
+      mutable: true
+      description: >
+        Controls whether the Parquet reader uses page-level min/max index to skip
+        irrelevant data pages within row groups. Gated by BE config
+        parquet_page_index_enable: if the BE config is false, this session variable
+        has no effect.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1041
+            context: "constant ENABLE_PARQUET_READER_PAGE_INDEX"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3267
+            context: "@VarAttr field enableParquetReaderPageIndex = true"
+        usage:
+          - file: "be/src/connector/hive_connector.cpp"
+            line: 853
+            context: "Two-level gating: BE config AND session variable determine parquet_page_index_enable in scanner_params"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 350
+            context: "Field 171 in TQueryOptions"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 6170
+            context: "tResult.setEnable_parquet_reader_page_index()"
+      behavior:
+        "true": "Parquet reader skips irrelevant pages within row groups using page-level min/max statistics, reducing I/O and decoding"
+        "false": "All pages in matching row groups are read and decoded"
+      related_variables:
+        - "parquet_page_index_enable (BE config)"
+        - "enable_parquet_reader_bloom_filter"
+
+  orc_session_variables:
+
+    - name: "orc_use_column_names"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls whether ORC file columns are accessed by name rather than by ordinal
+        position. By default, columns in ORC files are accessed by their ordinal
+        position in the Hive table definition. Enable this when ORC file column order
+        differs from the table schema (e.g., after schema evolution with column
+        additions/removals).
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 731
+            context: "constant ORC_USE_COLUMN_NAMES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3234
+            context: "@VarAttr field orcUseColumnNames = false"
+        usage:
+          - file: "be/src/connector/hive_connector.cpp"
+            line: 866
+            context: "Passed to scanner_params.orc_use_column_names from query_options"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 323
+            context: "Field 131 in TQueryOptions"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 6167
+            context: "tResult.setOrc_use_column_names()"
+      behavior:
+        "true": "ORC reader matches columns by name; robust against schema evolution"
+        "false": "ORC reader matches columns by ordinal position; faster but fragile with schema changes"
+      related_variables: []
+
+  late_materialization_session_variables:
+
+    - name: "enable_predicate_col_late_materialize"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls predicate-column late materialization in the OLAP storage engine.
+        When enabled, during segment iteration, predicate columns are read and
+        evaluated first. Non-predicate output columns are only read for rows that
+        pass the predicate filter, reducing I/O for selective queries on native
+        StarRocks tables.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1081
+            context: "constant ENABLE_PREDICATE_COL_LATE_MATERIALIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2286
+            context: "@VarAttr field enablePredicateColLateMaterialize = true"
+        usage:
+          - file: "be/src/storage/rowset/segment_iterator.cpp"
+            line: 2814
+            context: "Gates predicate-column late materialization in segment iteration"
+          - file: "be/src/storage/rowset/segment_iterator.cpp"
+            line: 1358
+            context: "Checks selectivity to decide if late materialization applies"
+          - file: "be/src/exec/pipeline/scan/olap_chunk_source.cpp"
+            line: 267
+            context: "Propagated from query_options to storage reader params"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 364
+            context: "Field 202 in TQueryOptions"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 6095
+            context: "tResult.setEnable_predicate_col_late_materialize()"
+      behavior:
+        "true": "Predicate columns are read first; non-predicate columns only read for qualifying rows"
+        "false": "All columns read together regardless of predicate evaluation"
+      related_variables:
+        - "late_materialization_ratio (BE config)"
+        - "metric_late_materialization_ratio (BE config)"
+
+    - name: "enable_global_late_materialization"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables global late materialization optimization in the FE query optimizer.
+        When enabled, the GlobalLateMaterializationRewriter rewrites the query plan
+        to defer reading of non-essential columns until after filtering, across
+        multiple operators (not just within a single scan). This is a plan-level
+        optimization distinct from the storage-level late materialization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1070
+            context: "constant ENABLE_GLOBAL_LATE_MATERIALIZATION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2201
+            context: "@VarAttr field enableGlobalLateMaterialization = false"
+        usage:
+          - file: "fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java"
+            line: 72
+            context: "Gates the global late materialization rewrite pass"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 366
+            context: "Field 210 in TQueryOptions"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 6112
+            context: "tResult.setEnable_global_late_materialization()"
+      behavior:
+        "true": "Optimizer applies global late materialization rewrite; defers column reads across operators"
+        "false": "Global late materialization rewrite is skipped"
+      related_variables:
+        - "global_late_materialization_max_fetch_ops"
+        - "global_late_materialization_max_limit"
+
+    - name: "global_late_materialization_max_fetch_ops"
+      type: Integer
+      default: 4
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of fetch operators allowed in a global late materialization
+        plan. Limits the complexity of the rewritten plan to avoid excessive
+        late-fetch overhead.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1071
+            context: "constant GLOBAL_LATE_MATERIALIZE_MAX_FETCH_OPS"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2204
+            context: "@VarAttr field globalLateMaterializeMaxFetchOps = 4"
+        usage:
+          - file: "fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java"
+            line: 72
+            context: "Used as limit in the global late materialization rewriter"
+        thrift_propagation: null
+      behavior:
+        low_values: "Fewer fetch operators; simpler plans but less aggressive late materialization"
+        high_values: "More fetch operators allowed; more aggressive deferral of column reads"
+      related_variables:
+        - "enable_global_late_materialization"
+        - "global_late_materialization_max_limit"
+
+    - name: "global_late_materialization_max_limit"
+      type: Integer
+      default: 4096
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum LIMIT value for queries eligible for global late materialization.
+        Queries with a LIMIT exceeding this value will not use the optimization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1072
+            context: "constant GLOBAL_LATE_MATERIALIZE_MAX_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2206
+            context: "@VarAttr field globalLateMaterializeMaxLimit = 4096"
+        usage:
+          - file: "fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java"
+            line: 72
+            context: "Used as eligibility threshold in the global late materialization rewriter"
+        thrift_propagation: null
+      behavior:
+        low_values: "Only very small LIMIT queries qualify for global late materialization"
+        high_values: "More queries qualify for the optimization"
+      related_variables:
+        - "enable_global_late_materialization"
+        - "global_late_materialization_max_fetch_ops"
+
+    - name: "join_late_materialization"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables late materialization for join operators. When enabled, the join node
+        defers reading of non-join columns until after the join probe phase, reducing
+        data shuffled through the join.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 362
+            context: "constant JOIN_LATE_MATERIALIZATION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1696
+            context: "@VarAttr field joinLateMaterialization = false"
+        usage:
+          - file: "fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java"
+            line: 3128
+            context: "Sets joinNode.setEnableLateMaterialization() in plan fragment builder"
+        thrift_propagation: null
+      behavior:
+        "true": "Join operators defer non-join-key column reads until after probe"
+        "false": "All columns are materialized before the join"
+      related_variables:
+        - "enable_global_late_materialization"
+
+    - name: "full_sort_late_materialization"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables late materialization for full sort (ORDER BY) operations. When enabled,
+        only order-by columns are permuted during the cascading merge phase; non-order-by
+        output columns are permuted afterward according to the ordinal column. Reduces
+        data movement during sorting.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 873
+            context: "constant FULL_SORT_LATE_MATERIALIZATION_V2 (internal name)"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 874
+            context: "constant FULL_SORT_LATE_MATERIALIZATION (alias/show name)"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2841
+            context: "@VarAttr field fullSortLateMaterialization = true, alias/show = full_sort_late_materialization"
+        usage:
+          - file: "fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java"
+            line: 246
+            context: "msg.sort_node.setLate_materialization() — passes to BE sort execution"
+        thrift_propagation: null
+      behavior:
+        "true": "Only sort-key columns are permuted during merge sort; output columns fetched after"
+        "false": "All columns are permuted during the sort merge"
+      related_variables:
+        - "parallel_merge_late_materialization_mode"
+
+    - name: "parallel_merge_late_materialization_mode"
+      type: String
+      default: "auto"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls late materialization mode for parallel merge sort in SortNode and
+        ExchangeNode. Valid values: auto, always, never. In auto mode, the optimizer
+        decides based on query characteristics.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 640
+            context: "constant PARALLEL_MERGE_LATE_MATERIALIZATION_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2030
+            context: "@VarAttr field parallelMergeLateMaterializationMode = AUTO"
+        usage:
+          - file: "fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java"
+            line: 248
+            context: "Converts to TLateMaterializeMode and sets parallel_merge_late_materialize_mode on sort_node"
+          - file: "fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java"
+            line: 217
+            context: "Converts to TLateMaterializeMode and sets parallel_merge_late_materialize_mode on exchange_node"
+        thrift_propagation: null
+      behavior:
+        "auto": "Optimizer decides whether to use late materialization in parallel merge"
+        "always": "Always use late materialization in parallel merge sort"
+        "never": "Never use late materialization in parallel merge sort"
+      related_variables:
+        - "full_sort_late_materialization"
+
+  parquet_be_configs:
+
+    - name: "parquet_coalesce_read_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables coalesced I/O reads for Parquet files. When enabled, multiple small
+        read requests are merged into larger sequential reads to reduce I/O overhead.
+        Controlled by io_coalesce_read_max_buffer_size and io_coalesce_read_max_distance_size.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1118
+            context: "CONF_mBool(parquet_coalesce_read_enable, \"true\")"
+        usage:
+          - file: "be/src/formats/parquet/group_reader.cpp"
+            line: 107
+            context: "Gates whether shared buffered stream is used for coalesced reads in row group reader"
+          - file: "be/src/formats/parquet/file_reader.cpp"
+            line: 233
+            context: "Gates coalesced reading at file-reader level"
+        thrift_propagation: null
+      behavior:
+        "true": "Small reads are coalesced into larger I/O operations, reducing syscall overhead"
+        "false": "Each column chunk/page is read individually"
+      related_variables:
+        - "io_coalesce_read_max_buffer_size (BE config)"
+        - "io_coalesce_read_max_distance_size (BE config)"
+        - "io_coalesce_adaptive_lazy_active (BE config)"
+
+    - name: "parquet_late_materialization_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables late materialization within the Parquet reader. When enabled, predicate
+        columns are read and evaluated first within a row group; non-predicate columns
+        are only decoded for rows that pass the filter.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1119
+            context: "CONF_mBool(parquet_late_materialization_enable, \"true\")"
+        usage:
+          - file: "be/src/formats/parquet/group_reader.cpp"
+            line: 463
+            context: "Gates late materialization path in Parquet group reader"
+        thrift_propagation: null
+      behavior:
+        "true": "Predicate columns read first; non-predicate columns only decoded for qualifying rows"
+        "false": "All columns decoded together regardless of predicates"
+      related_variables:
+        - "enable_predicate_col_late_materialize (session variable)"
+
+    - name: "parquet_page_index_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: false
+      description: >
+        Master BE-level switch for Parquet page index usage. If disabled, the session
+        variable enable_parquet_reader_page_index has no effect. This is the first
+        gate in the two-level check at hive_connector.cpp.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1120
+            context: "CONF_Bool(parquet_page_index_enable, \"true\")"
+        usage:
+          - file: "be/src/connector/hive_connector.cpp"
+            line: 854
+            context: "First gate: if false, page index is disabled regardless of session variable"
+        thrift_propagation: null
+      behavior:
+        "true": "Page index usage controlled by session variable enable_parquet_reader_page_index"
+        "false": "Page index is unconditionally disabled on this BE"
+      related_variables:
+        - "enable_parquet_reader_page_index (session variable)"
+
+    - name: "parquet_reader_bloom_filter_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Master BE-level switch for Parquet bloom filter usage. If disabled, the session
+        variable enable_parquet_reader_bloom_filter has no effect. This is the first
+        gate in the two-level check at hive_connector.cpp.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1121
+            context: "CONF_mBool(parquet_reader_bloom_filter_enable, \"true\")"
+        usage:
+          - file: "be/src/connector/hive_connector.cpp"
+            line: 859
+            context: "First gate: if false, bloom filter is disabled regardless of session variable"
+        thrift_propagation: null
+      behavior:
+        "true": "Bloom filter usage controlled by session variable enable_parquet_reader_bloom_filter"
+        "false": "Bloom filter is unconditionally disabled on this BE"
+      related_variables:
+        - "enable_parquet_reader_bloom_filter (session variable)"
+
+    - name: "parquet_statistics_process_more_filter_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables processing of additional statistics-based filters in the Parquet reader.
+        Exact usage not traced to a specific code path — may be consumed via scanner
+        context struct or is a feature flag for future use.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1122
+            context: "CONF_mBool(parquet_statistics_process_more_filter_enable, \"true\")"
+        usage: []
+        thrift_propagation: null
+      behavior:
+        "true": "Additional statistics-based filters applied in Parquet reading"
+        "false": "Only standard statistics filters applied"
+      related_variables:
+        - "parquet_page_index_enable"
+
+    - name: "parquet_fast_timezone_conversion"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables a fast-path timezone conversion for Parquet timestamp columns. When
+        enabled (or when timezone offset is 0), uses an optimized conversion path
+        in the column converter. When disabled, uses the standard timezone conversion
+        which is more accurate for DST transitions.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1123
+            context: "CONF_mBool(parquet_fast_timezone_conversion, \"false\")"
+        usage:
+          - file: "be/src/formats/parquet/column_converter.cpp"
+            line: 709
+            context: "Gates fast-path timestamp conversion for INT96 timestamps"
+          - file: "be/src/formats/parquet/column_converter.cpp"
+            line: 816
+            context: "Gates fast-path timestamp conversion for INT64 timestamps"
+        thrift_propagation: null
+      behavior:
+        "true": "Uses fast timezone conversion; may be inaccurate near DST transitions"
+        "false": "Uses standard timezone conversion; always correct but slower"
+      related_variables: []
+
+    - name: "parquet_push_down_filter_to_decoder_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables pushing predicate filters down to the Parquet page decoder level.
+        When enabled, filters are applied during decoding rather than after, avoiding
+        materialization of filtered-out values.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1124
+            context: "CONF_mBool(parquet_push_down_filter_to_decoder_enable, \"true\")"
+        usage:
+          - file: "be/src/formats/parquet/stored_column_reader.h"
+            line: 156
+            context: "Gates whether filter is pushed to decoder in StoredColumnReader"
+        thrift_propagation: null
+      behavior:
+        "true": "Filters are applied at the decoder level; fewer values materialized"
+        "false": "All values decoded first, then filtered"
+      related_variables:
+        - "parquet_late_materialization_enable"
+
+    - name: "parquet_cache_aware_dict_decoder_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables a cache-aware dictionary decoder for Parquet columns. When dictionary
+        size exceeds a threshold, uses a cache-friendly decoding strategy to improve
+        CPU cache hit rates during dictionary lookups.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1125
+            context: "CONF_mBool(parquet_cache_aware_dict_decoder_enable, \"true\")"
+        usage:
+          - file: "be/src/formats/parquet/encoding_dict.h"
+            line: 122
+            context: "Gates cache-aware decoding path when dict size exceeds threshold"
+          - file: "be/src/formats/parquet/encoding_dict.h"
+            line: 137
+            context: "Gates cache-aware batch decoding path"
+        thrift_propagation: null
+      behavior:
+        "true": "Large dictionaries use cache-friendly decoding strategy"
+        "false": "Standard dictionary decoding regardless of dictionary size"
+      related_variables: []
+
+    - name: "parquet_reader_enable_adpative_bloom_filter"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables adaptive bloom filter optimization in the Parquet column reader.
+        Note: the config name contains a typo (\"adpative\" instead of \"adaptive\").
+        When disabled, the adaptive bloom filter logic is bypassed.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1127
+            context: "CONF_mBool(parquet_reader_enable_adpative_bloom_filter, \"true\")"
+        usage:
+          - file: "be/src/formats/parquet/column_reader.cpp"
+            line: 203
+            context: "Early return if adaptive bloom filter is disabled"
+        thrift_propagation: null
+      behavior:
+        "true": "Adaptive bloom filter optimization active in column reader"
+        "false": "Adaptive bloom filter optimization bypassed"
+      related_variables:
+        - "parquet_reader_bloom_filter_enable"
+        - "enable_parquet_reader_bloom_filter (session variable)"
+
+    - name: "parquet_page_cache_decompress_threshold"
+      type: Double
+      default: 1.5
+      scope: "BE config"
+      mutable: false
+      description: >
+        Threshold ratio for deciding whether to cache decompressed Parquet page data.
+        If the decompressed size exceeds compressed_page_size * this threshold, the
+        page data is decompressed into a separate buffer rather than decompressing
+        in-place from the page cache.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1128
+            context: "CONF_Double(parquet_page_cache_decompress_threshold, \"1.5\")"
+        usage:
+          - file: "be/src/formats/parquet/page_reader.cpp"
+            line: 277
+            context: "Compares decompressed size against threshold * compressed_page_size"
+        thrift_propagation: null
+      behavior:
+        low_values: "More pages treated as needing separate decompression buffer"
+        high_values: "More pages decompressed in-place from cache"
+      related_variables:
+        - "enable_adjustment_page_cache_skip"
+
+    - name: "enable_adjustment_page_cache_skip"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Controls whether the Parquet page reader adjusts page cache skipping behavior
+        based on whether the page data needs decompression. When enabled and the page
+        does not need decompressed caching, it can skip the cache.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1129
+            context: "CONF_mBool(enable_adjustment_page_cache_skip, \"true\")"
+        usage:
+          - file: "be/src/formats/parquet/page_reader.cpp"
+            line: 90
+            context: "Gates page cache skip adjustment based on decompression status"
+        thrift_propagation: null
+      behavior:
+        "true": "Page cache skipping is adjusted based on decompression needs"
+        "false": "No adjustment to page cache skipping"
+      related_variables:
+        - "parquet_page_cache_decompress_threshold"
+
+  orc_be_configs:
+
+    - name: "enable_orc_late_materialization"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: false
+      description: >
+        Enables late materialization in the ORC scanner. When enabled and there are
+        lazy-load slots, predicate columns are read and evaluated first; non-predicate
+        columns are only read for qualifying rows.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1100
+            context: "CONF_Bool(enable_orc_late_materialization, \"true\")"
+        usage:
+          - file: "be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp"
+            line: 532
+            context: "Gates ORC late materialization when lazy_load_slots exist"
+        thrift_propagation: null
+      behavior:
+        "true": "ORC reader uses late materialization for selective queries"
+        "false": "All columns read together regardless of predicates"
+      related_variables:
+        - "parquet_late_materialization_enable"
+
+    - name: "enable_orc_libdeflate_decompression"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: false
+      description: >
+        Enables use of the libdeflate library for ORC decompression instead of the
+        default zlib. libdeflate is significantly faster for deflate/zlib decompression.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1101
+            context: "CONF_Bool(enable_orc_libdeflate_decompression, \"true\")"
+        usage:
+          - file: "be/src/formats/orc/apache-orc/c++/src/Compression.cc"
+            line: 1159
+            context: "Gates libdeflate usage in ORC decompression"
+        thrift_propagation: null
+      behavior:
+        "true": "Uses libdeflate for faster ORC decompression"
+        "false": "Uses standard zlib for ORC decompression"
+      related_variables: []
+
+    - name: "orc_natural_read_size"
+      type: Integer
+      default: 8388608
+      scope: "BE config"
+      mutable: false
+      description: >
+        The natural read size (in bytes) for ORC file I/O. Default is 8MB. This is
+        the size hint returned to the ORC library for its read buffer allocation.
+        After a seek, the read size is reduced to 1/4 of this value.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1102
+            context: "CONF_Int32(orc_natural_read_size, \"8388608\")"
+        usage:
+          - file: "be/src/formats/orc/orc_input_stream.h"
+            line: 40
+            context: "getNaturalReadSize() returns config::orc_natural_read_size"
+          - file: "be/src/formats/orc/orc_input_stream.h"
+            line: 56
+            context: "getNaturalReadSizeAfterSeek() returns orc_natural_read_size / 4"
+        thrift_propagation: null
+      behavior:
+        low_values: "Smaller read buffers; more I/O calls but less memory"
+        high_values: "Larger read buffers; fewer I/O calls but more memory per stream"
+      related_variables:
+        - "orc_coalesce_read_enable"
+
+    - name: "orc_coalesce_read_enable"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables coalesced I/O reads for ORC files. When enabled, multiple small
+        read requests are merged into larger sequential reads.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1103
+            context: "CONF_mBool(orc_coalesce_read_enable, \"true\")"
+        usage:
+          - file: "be/src/formats/orc/orc_input_stream.h"
+            line: 66
+            context: "isIOCoalesceEnabled() returns config::orc_coalesce_read_enable"
+        thrift_propagation: null
+      behavior:
+        "true": "Small ORC reads are coalesced into larger I/O operations"
+        "false": "Each ORC read request is executed individually"
+      related_variables:
+        - "io_coalesce_read_max_buffer_size (BE config)"
+        - "io_coalesce_read_max_distance_size (BE config)"
+
+    - name: "orc_tiny_stripe_threshold_size"
+      type: Integer
+      default: 8388608
+      scope: "BE config"
+      mutable: false
+      description: >
+        Threshold size (in bytes) for ORC tiny stripe optimization. Default is 8MB.
+        When all stripes in an ORC file are smaller than this threshold, the tiny
+        stripe optimization kicks in, coalescing stripe reads into merged disk ranges.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1106
+            context: "CONF_Int32(orc_tiny_stripe_threshold_size, \"8388608\")"
+        usage:
+          - file: "be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp"
+            line: 377
+            context: "Checks if stripe length exceeds threshold to decide tiny stripe opt"
+          - file: "be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp"
+            line: 386
+            context: "Used as max buffer size in merge_adjacent_disk_ranges for tiny stripes"
+        thrift_propagation: null
+      behavior:
+        low_values: "Fewer stripes qualify as tiny; less merging"
+        high_values: "More stripes qualify as tiny; more aggressive read merging"
+      related_variables:
+        - "orc_coalesce_read_enable"
+
+    - name: "orc_loading_buffer_size"
+      type: Integer
+      default: 8388608
+      scope: "BE config"
+      mutable: false
+      description: >
+        When an ORC file is smaller than this size (in bytes), the entire file is
+        read at once instead of reading the footer first. Default is 8MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1110
+            context: "CONF_Int32(orc_loading_buffer_size, \"8388608\")"
+        usage:
+          - file: "be/src/exec/file_scanner/orc_scanner.cpp"
+            line: 235
+            context: "If file_size < orc_loading_buffer_size, reads whole file at once"
+        thrift_propagation: null
+      behavior:
+        low_values: "Fewer files qualify for whole-file read"
+        high_values: "More files read entirely at once, avoiding separate footer read"
+      related_variables: []
+
+    - name: "orc_writer_version"
+      type: Integer
+      default: -1
+      scope: "BE config"
+      mutable: true
+      description: >
+        Overrides the ORC writer version in the postscript. Value of -1 means no
+        override (use default). This is a workaround for an out-of-bound bug in
+        the Hive ORC reader (see ORC-125).
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1115
+            context: "CONF_mInt32(orc_writer_version, \"-1\")"
+        usage:
+          - file: "be/src/formats/orc/apache-orc/c++/src/Writer.cc"
+            line: 390
+            context: "If not -1, overrides postScript.set_writerversion()"
+        thrift_propagation: null
+      behavior:
+        "-1": "Default ORC writer version used"
+        "other": "Specified version written to ORC postscript as workaround"
+      related_variables: []
+
+  native_storage_late_materialization_be_configs:
+
+    - name: "late_materialization_ratio"
+      type: Integer
+      default: 10
+      scope: "BE config"
+      mutable: true
+      description: >
+        Controls the late materialization selectivity threshold for OLAP storage scans.
+        If the predicate selectivity ratio is below this threshold (as a percentage),
+        late materialization is used. A value of 1000 always enables late materialization.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 898
+            context: "CONF_mInt32(late_materialization_ratio, \"10\")"
+        usage:
+          - file: "be/src/storage/rowset/segment_iterator.cpp"
+            line: 2771
+            context: "_late_materialization_ratio = config::late_materialization_ratio"
+        thrift_propagation: null
+      behavior:
+        low_values: "Late materialization only for very selective predicates"
+        high_values: "Late materialization for less selective predicates; 1000 = always"
+      related_variables:
+        - "metric_late_materialization_ratio"
+        - "enable_predicate_col_late_materialize (session variable)"
+
+    - name: "metric_late_materialization_ratio"
+      type: Integer
+      default: 1000
+      scope: "BE config"
+      mutable: false
+      description: >
+        Late materialization ratio specifically for metric column types. Default of
+        1000 means late materialization is always used for metric columns, since
+        metric columns are typically larger and benefit more from deferred reads.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 903
+            context: "CONF_Int32(metric_late_materialization_ratio, \"1000\")"
+        usage:
+          - file: "be/src/storage/rowset/segment_iterator.cpp"
+            line: 2783
+            context: "Overrides _late_materialization_ratio for metric type columns"
+        thrift_propagation: null
+      behavior:
+        low_values: "Late materialization for metric columns only when highly selective"
+        "1000": "Always use late materialization for metric columns (default)"
+      related_variables:
+        - "late_materialization_ratio"
+
+  io_coalesce_be_configs:
+
+    - name: "io_coalesce_read_max_buffer_size"
+      type: Integer
+      default: 8388608
+      scope: "BE config"
+      mutable: false
+      description: >
+        Maximum buffer size (in bytes) for coalesced I/O reads. Default is 8MB.
+        Multiple adjacent small reads are merged into a single read up to this size.
+        Used by both Parquet and ORC coalesced reading, as well as HDFS scanner,
+        Iceberg delete builder, and cache select scanner.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1131
+            context: "CONF_Int32(io_coalesce_read_max_buffer_size, \"8388608\")"
+        usage:
+          - file: "be/src/exec/hdfs_scanner/hdfs_scanner.cpp"
+            line: 332
+            context: "Used as max_buffer_size in SharedBufferedInputStream options"
+          - file: "be/src/storage/rowset/segment_iterator.cpp"
+            line: 1227
+            context: "Used for lake storage coalesced reads"
+          - file: "be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp"
+            line: 387
+            context: "Used in ORC tiny stripe merge"
+        thrift_propagation: null
+      behavior:
+        low_values: "Smaller merged reads; more I/O calls"
+        high_values: "Larger merged reads; fewer I/O calls but more memory"
+      related_variables:
+        - "io_coalesce_read_max_distance_size"
+        - "parquet_coalesce_read_enable"
+        - "orc_coalesce_read_enable"
+
+    - name: "io_coalesce_read_max_distance_size"
+      type: Integer
+      default: 1048576
+      scope: "BE config"
+      mutable: false
+      description: >
+        Maximum gap (in bytes) between two read ranges that can still be coalesced
+        into a single read. Default is 1MB. If two reads are farther apart than
+        this distance, they remain separate I/O operations.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1132
+            context: "CONF_Int32(io_coalesce_read_max_distance_size, \"1048576\")"
+        usage:
+          - file: "be/src/exec/hdfs_scanner/hdfs_scanner.cpp"
+            line: 331
+            context: "Used as max_dist_size in SharedBufferedInputStream options"
+          - file: "be/src/storage/rowset/segment_iterator.cpp"
+            line: 1226
+            context: "Used for lake storage coalesced reads"
+        thrift_propagation: null
+      behavior:
+        low_values: "Only very close reads are merged; more separate I/O operations"
+        high_values: "Reads with larger gaps are merged; more wasted read-ahead bytes"
+      related_variables:
+        - "io_coalesce_read_max_buffer_size"
+
+    - name: "io_coalesce_adaptive_lazy_active"
+      type: Boolean
+      default: true
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables adaptive lazy activation for coalesced I/O. When enabled, the
+        shared buffered input stream adjusts coalescing behavior based on whether
+        columns are lazily loaded (late materialization) vs eagerly loaded.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1133
+            context: "CONF_mBool(io_coalesce_adaptive_lazy_active, \"true\")"
+        usage:
+          - file: "be/src/formats/parquet/group_reader.cpp"
+            line: 112
+            context: "Controls counter-based vs direct coalescing in group reader"
+          - file: "be/src/io/shared_buffered_input_stream.cpp"
+            line: 190
+            context: "Gates adaptive lazy column handling in shared buffered stream"
+          - file: "be/src/formats/orc/orc_input_stream.h"
+            line: 67
+            context: "isIOAdaptiveCoalesceEnabled() returns this config"
+        thrift_propagation: null
+      behavior:
+        "true": "Coalescing adapts based on lazy vs eager column access patterns"
+        "false": "Coalescing uses static strategy regardless of column access pattern"
+      related_variables:
+        - "parquet_coalesce_read_enable"
+        - "orc_coalesce_read_enable"
+
+    - name: "io_coalesce_lake_read_enable"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables coalesced I/O reads for lake (shared-data) storage. When enabled,
+        column reads in segment iteration are coalesced for shared-data mode. Default
+        is disabled because lake storage has different I/O characteristics than local
+        storage.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1097
+            context: "CONF_mBool(io_coalesce_lake_read_enable, \"false\")"
+        usage:
+          - file: "be/src/storage/rowset/segment_iterator.cpp"
+            line: 1220
+            context: "Gates coalesced I/O for lake storage in segment iteration"
+          - file: "be/src/storage/rowset/scalar_column_iterator.cpp"
+            line: 224
+            context: "Gates coalesced read paths in scalar column iterator"
+        thrift_propagation: null
+      behavior:
+        "true": "Lake storage uses coalesced I/O reads in segment iteration"
+        "false": "Lake storage uses individual reads"
+      related_variables:
+        - "io_coalesce_read_max_buffer_size"
+        - "io_coalesce_read_max_distance_size"
+
+    - name: "arrow_io_coalesce_read_max_buffer_size"
+      type: Long
+      default: 8388608
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum buffer size (in bytes) for coalesced I/O reads in the Arrow-based
+        reader path. Default is 8MB. Analogous to io_coalesce_read_max_buffer_size
+        but for Arrow file readers.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1716
+            context: "CONF_mInt64(arrow_io_coalesce_read_max_buffer_size, \"8388608\")"
+        usage: []
+        thrift_propagation: null
+      behavior:
+        low_values: "Smaller merged reads in Arrow path"
+        high_values: "Larger merged reads in Arrow path"
+      related_variables:
+        - "arrow_io_coalesce_read_max_distance_size"
+        - "io_coalesce_read_max_buffer_size"
+
+    - name: "arrow_io_coalesce_read_max_distance_size"
+      type: Long
+      default: 1048576
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum gap (in bytes) between two read ranges that can still be coalesced
+        in the Arrow-based reader path. Default is 1MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1717
+            context: "CONF_mInt64(arrow_io_coalesce_read_max_distance_size, \"1048576\")"
+        usage: []
+        thrift_propagation: null
+      behavior:
+        low_values: "Only very close reads merged in Arrow path"
+        high_values: "Reads with larger gaps merged in Arrow path"
+      related_variables:
+        - "arrow_io_coalesce_read_max_buffer_size"
+        - "io_coalesce_read_max_distance_size"

--- a/param-docs/05_memory_management.yml
+++ b/param-docs/05_memory_management.yml
@@ -1,0 +1,801 @@
+# StarRocks Parameter Dictionary - Memory Management
+# Memory limits, spill to disk, memory pools, buffer management
+
+memory_management:
+
+  memory_session_variables:
+
+    - name: "exec_mem_limit"
+      type: Long
+      default: 2147483648
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Per-fragment execution memory limit in bytes. Default is 2GB. This is a legacy
+        parameter; prefer query_mem_limit for per-query memory control. Sent to BE as
+        mem_limit in TQueryOptions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 136
+            context: "constant EXEC_MEM_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1221
+            context: "@VarAttr field maxExecMemByte = 2147483648, INVISIBLE"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6016
+            context: "Field mem_limit in TQueryOptions"
+      related_variables:
+        - "query_mem_limit"
+
+    - name: "query_mem_limit"
+      type: Long
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Per-query memory limit in bytes. 0 means the system automatically determines
+        the limit based on available memory and query complexity. This is the preferred
+        way to control query memory.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 155
+            context: "constant QUERY_MEM_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1227
+            context: "@VarAttr field queryMemLimit = 0"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6017
+            context: "Field query_mem_limit in TQueryOptions"
+      behavior:
+        "0": "System auto-determines based on available memory"
+        ">0": "Hard memory limit per query in bytes"
+
+    - name: "load_mem_limit"
+      type: Long
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Memory limit for load (INSERT/LOAD) operations in bytes. 0 means use the
+        default exec_mem_limit.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 148
+            context: "constant LOAD_MEM_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1224
+            context: "@VarAttr field loadMemLimit = 0"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6032
+            context: "Field load_mem_limit in TQueryOptions"
+
+    - name: "query_timeout"
+      type: Integer
+      default: 300
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Query timeout in seconds. Queries running longer than this are cancelled.
+        Default is 300 seconds (5 minutes).
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 157
+            context: "constant QUERY_TIMEOUT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1231
+            context: "@VarAttr field queryTimeoutS = 300"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            line: 6021
+            context: "Field query_timeout in TQueryOptions"
+
+  spill_session_variables:
+
+    - name: "enable_spill"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Master switch for spill to disk. When enabled, operators that exceed their memory
+        budget can spill intermediate results to disk instead of failing.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant ENABLE_SPILL"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field enableSpill = false"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "TSpillOptions in TQueryOptions"
+      related_variables:
+        - "spill_mode"
+        - "spillable_operator_mask"
+
+    - name: "enable_spill_to_remote_storage"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables spilling to remote storage (e.g., S3, HDFS) in addition to local disk.
+        Useful when local disk space is limited.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant ENABLE_SPILL_TO_REMOTE_STORAGE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field enableSpillToRemoteStorage = false"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "disable_spill_to_local_disk"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Disables spilling to local disk. When combined with enable_spill_to_remote_storage,
+        forces all spill to go to remote storage only.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant DISABLE_SPILL_TO_LOCAL_DISK"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field disableSpillToLocalDisk = false"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spillable_operator_mask"
+      type: Long
+      default: -1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Bitmask controlling which operators can spill. -1 means all operators are spillable.
+        Each bit corresponds to an operator type.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILLABLE_OPERATOR_MASK"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillableOperatorMask = -1"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field spillable_operator_mask in TSpillOptions"
+
+    - name: "spill_mode"
+      type: String
+      default: "auto"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls when spilling is triggered. Values: auto (system decides based on memory
+        pressure), force (always spill when possible).
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillMode = 'auto'"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field spill_mode in TSpillOptions"
+      behavior:
+        "auto": "Spill only when memory pressure is detected"
+        "force": "Spill aggressively to minimize memory usage"
+
+    - name: "enable_agg_spill_preaggregation"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables pre-aggregation before spilling in aggregation operators. Reduces the
+        volume of data written to disk during spill.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant ENABLE_AGG_SPILL_PREAGGREGATION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field enableAggSpillPreaggregation = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_partitionwise_agg"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables partition-wise aggregation during spill. Partitions data before spilling
+        to enable more efficient restore and aggregation.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_PARTITIONWISE_AGG"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillPartitionwiseAgg = false"
+        thrift_propagation: null
+
+    - name: "spill_partitionwise_agg_partition_num"
+      type: Integer
+      default: 128
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Number of partitions for partition-wise aggregation during spill.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_PARTITIONWISE_AGG_PARTITION_NUM"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillPartitionwiseAggPartitionNum = 128"
+        thrift_propagation: null
+
+    - name: "spill_partitionwise_agg_skew_elimination"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables skew elimination during partition-wise aggregation spill. Handles
+        data skew by rebalancing partitions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_PARTITIONWISE_AGG_SKEW_ELIMINATION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillPartitionwiseAggSkewElimination = true"
+        thrift_propagation: null
+
+    - name: "enable_spill_buffer_read"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables buffered reads when restoring spilled data from disk.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant ENABLE_SPILL_BUFFER_READ"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field enableSpillBufferRead = true"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "max_spill_read_buffer_bytes_per_driver"
+      type: Long
+      default: 4194304
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum bytes for spill read buffer per pipeline driver. Default is 4MB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant MAX_SPILL_READ_BUFFER_BYTES_PER_DRIVER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field maxSpillReadBufferBytesPerDriver = 4194304"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_hash_join_probe_op_max_bytes"
+      type: Long
+      default: 2147483648
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum bytes for hash join probe operator before spilling to disk.
+        Default is 2GB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 244
+            context: "constant SPILL_HASH_JOIN_PROBE_OP_MAX_BYTES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1635
+            context: "@VarAttr field spillHashJoinProbeOpMaxBytes = 2147483648, INVISIBLE"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field 25 in TSpillOptions"
+
+    - name: "spill_mem_table_size"
+      type: Long
+      default: 104857600
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Size (bytes) of in-memory table before triggering spill. Default is 100MB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_MEM_TABLE_SIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillMemTableSize"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_mem_table_num"
+      type: Integer
+      default: 2
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Number of in-memory tables before triggering spill.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_MEM_TABLE_NUM"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillMemTableNum"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_mem_limit_threshold"
+      type: Double
+      default: 0.8
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Memory usage ratio threshold that triggers spilling. When memory usage exceeds
+        this fraction of the limit, spilling begins.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_MEM_LIMIT_THRESHOLD"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillMemLimitThreshold = 0.8"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_operator_min_bytes"
+      type: Long
+      default: 10485760
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Minimum bytes an operator must hold before it can be selected as a spill candidate.
+        Default is 10MB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_OPERATOR_MIN_BYTES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillOperatorMinBytes"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_operator_max_bytes"
+      type: Long
+      default: 1073741824
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum bytes an operator can hold before being forced to spill. Default is 1GB.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_OPERATOR_MAX_BYTES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillOperatorMaxBytes"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_revocable_max_bytes"
+      type: Long
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum revocable memory bytes before triggering spill. 0 means no limit.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_REVOCABLE_MAX_BYTES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillRevocableMaxBytes = 0"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_enable_direct_io"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables direct I/O for spill operations, bypassing OS page cache.
+        Reduces memory pressure from spill I/O but may be slower for small spills.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_ENABLE_DIRECT_IO"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillEnableDirectIO = false"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_enable_compaction"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables compaction of spilled data. Merges small spill files to reduce I/O
+        overhead during restore.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_ENABLE_COMPACTION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillEnableCompaction = false"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_rand_ratio"
+      type: Double
+      default: 0.0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Random spill ratio for testing. When > 0, randomly spills data with this probability
+        to test spill code paths. Should only be used for testing.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_RAND_RATIO"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillRandRatio = 0.0"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_encode_level"
+      type: Integer
+      default: 7
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Compression level for spilled data. Higher values produce smaller files but use
+        more CPU. Uses LZ4 compression by default.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_ENCODE_LEVEL"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillEncodeLevel = 7"
+        thrift_propagation:
+          - file: "gensrc/thrift/InternalService.thrift"
+            context: "Field in TSpillOptions"
+
+    - name: "spill_storage_volume"
+      type: String
+      default: ""
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Storage volume name for remote spill. When spilling to remote storage, this
+        specifies which configured storage volume to use.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant SPILL_STORAGE_VOLUME"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field spillStorageVolume = ''"
+        thrift_propagation: null
+
+    - name: "enable_connector_sink_spill"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables spilling for connector sink (external table write) operators.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant ENABLE_CONNECTOR_SINK_SPILL"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field enableConnectorSinkSpill = false"
+        thrift_propagation: null
+      related_variables:
+        - "connector_sink_spill_mem_limit_threshold"
+
+    - name: "connector_sink_spill_mem_limit_threshold"
+      type: Double
+      default: 0.5
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Memory usage ratio threshold for triggering connector sink spill.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "constant CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            context: "@VarAttr field connectorSinkSpillMemLimitThreshold = 0.5"
+        thrift_propagation: null
+
+  memory_be_configs:
+
+    - name: "mem_limit"
+      type: String
+      default: "90%"
+      scope: "BE config"
+      mutable: false
+      description: >
+        Maximum memory the BE process can use. Can be a percentage of system memory
+        (e.g., "90%") or an absolute value (e.g., "64G"). This is the hard upper limit.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_String(mem_limit, \"90%\")"
+        thrift_propagation: null
+
+    - name: "memory_urgent_level"
+      type: Double
+      default: 0.9
+      scope: "BE config"
+      mutable: true
+      description: >
+        Memory usage ratio that triggers urgent memory reclamation. When usage exceeds
+        this fraction of mem_limit, aggressive memory freeing is performed.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(memory_urgent_level, \"0.9\")"
+        thrift_propagation: null
+
+    - name: "memory_high_level"
+      type: Double
+      default: 0.8
+      scope: "BE config"
+      mutable: true
+      description: >
+        Memory usage ratio that triggers high memory state. New queries may be rejected
+        or throttled above this level.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(memory_high_level, \"0.8\")"
+        thrift_propagation: null
+
+    - name: "query_max_memory_limit_percent"
+      type: Double
+      default: 0.9
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum fraction of process memory that a single query can use.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(query_max_memory_limit_percent, \"0.9\")"
+        thrift_propagation: null
+
+    - name: "load_process_max_memory_limit_bytes"
+      type: Long
+      default: 107374182400
+      scope: "BE config"
+      mutable: true
+      description: >
+        Absolute maximum memory (bytes) for all load processes. Default is 100GB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(load_process_max_memory_limit_bytes, \"107374182400\")"
+        thrift_propagation: null
+
+    - name: "load_process_max_memory_limit_percent"
+      type: Double
+      default: 0.3
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum fraction of process memory allocated to all load operations.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(load_process_max_memory_limit_percent, \"0.3\")"
+        thrift_propagation: null
+
+    - name: "compaction_max_memory_limit"
+      type: Long
+      default: -1
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum memory (bytes) for compaction operations. -1 means auto-calculated
+        based on available memory.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(compaction_max_memory_limit, \"-1\")"
+        thrift_propagation: null
+
+    - name: "write_buffer_size"
+      type: Long
+      default: 104857600
+      scope: "BE config"
+      mutable: true
+      description: >
+        Size (bytes) of the memtable write buffer. Default is 100MB. Data is flushed
+        to disk when the buffer reaches this size.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(write_buffer_size, \"104857600\")"
+        thrift_propagation: null
+
+    - name: "local_exchange_buffer_mem_limit_per_driver"
+      type: Long
+      default: 134217728
+      scope: "BE config"
+      mutable: true
+      description: >
+        Memory limit (bytes) for local exchange buffer per pipeline driver. Default is 128MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(local_exchange_buffer_mem_limit_per_driver, \"134217728\")"
+        thrift_propagation: null
+
+    - name: "streaming_agg_limited_memory_size"
+      type: Long
+      default: 134217728
+      scope: "BE config"
+      mutable: true
+      description: >
+        Memory limit (bytes) for streaming aggregation before switching to hash aggregation.
+        Default is 128MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(streaming_agg_limited_memory_size, \"134217728\")"
+        thrift_propagation: null
+
+    - name: "partition_hash_join_probe_limit_size"
+      type: Long
+      default: 134217728
+      scope: "BE config"
+      mutable: true
+      description: >
+        Memory limit (bytes) for partition hash join probe side buffer. Default is 128MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(partition_hash_join_probe_limit_size, \"134217728\")"
+        thrift_propagation: null
+
+    - name: "sink_buffer_mem_limit_per_driver"
+      type: Long
+      default: 67108864
+      scope: "BE config"
+      mutable: true
+      description: >
+        Memory limit (bytes) for sink buffer per pipeline driver. Default is 64MB.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(sink_buffer_mem_limit_per_driver, \"67108864\")"
+        thrift_propagation: null
+
+  spill_be_configs:
+
+    - name: "spill_local_storage_dir"
+      type: String
+      default: "${STARROCKS_HOME}/spill"
+      scope: "BE config"
+      mutable: false
+      description: >
+        Local directory for spill storage. Multiple directories can be separated by
+        semicolons for disk striping.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_String(spill_local_storage_dir, \"${STARROCKS_HOME}/spill\")"
+        thrift_propagation: null
+
+    - name: "spill_init_partition"
+      type: Integer
+      default: 16
+      scope: "BE config"
+      mutable: true
+      description: >
+        Initial number of partitions for spill operations.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(spill_init_partition, \"16\")"
+        thrift_propagation: null
+
+    - name: "spill_max_partition_level"
+      type: Integer
+      default: 7
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum partition recursion level for spill. Controls how many times spilled
+        partitions can be further split.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt32(spill_max_partition_level, \"7\")"
+        thrift_propagation: null
+
+    - name: "spill_max_partition_size"
+      type: Long
+      default: 0
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum size (bytes) per spill partition. 0 means no limit.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mInt64(spill_max_partition_size, \"0\")"
+        thrift_propagation: null
+
+    - name: "spill_max_dir_bytes_ratio"
+      type: Double
+      default: 0.8
+      scope: "BE config"
+      mutable: true
+      description: >
+        Maximum ratio of disk space that can be used for spill files in each spill directory.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(spill_max_dir_bytes_ratio, \"0.8\")"
+        thrift_propagation: null
+
+    - name: "enable_load_spill"
+      type: Boolean
+      default: false
+      scope: "BE config"
+      mutable: true
+      description: >
+        Enables spilling for load (data ingestion) operations. When enabled, load
+        operations that exceed memory can spill to disk.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mBool(enable_load_spill, \"false\")"
+        thrift_propagation: null
+
+    - name: "query_pool_spill_mem_limit_threshold"
+      type: Double
+      default: 1.0
+      scope: "BE config"
+      mutable: true
+      description: >
+        Query pool memory usage ratio that triggers spilling for queries in the pool.
+        Default 1.0 means spill is only triggered by individual query limits.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            context: "CONF_mDouble(query_pool_spill_mem_limit_threshold, \"1.0\")"
+        thrift_propagation: null

--- a/param-docs/06_parallelism_scheduling.yml
+++ b/param-docs/06_parallelism_scheduling.yml
@@ -1,0 +1,951 @@
+# StarRocks Parameter Dictionary - Parallelism and Scheduling
+# Pipeline engine, DOP, fragment parallelism, group execution, scheduling, worker threads
+
+parallelism_scheduling:
+
+  pipeline_engine:
+
+    - name: "enable_pipeline_engine"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables the pipeline execution engine. When enabled, queries are executed using
+        the pipeline model with driver-based scheduling rather than the traditional
+        thread-per-fragment model.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 297
+            context: "constant ENABLE_PIPELINE_ENGINE (alias/show)"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1116
+            context: "@VarAttr field enablePipelineEngine = true"
+        thrift_propagation: null
+      behavior:
+        "true": "Queries use pipeline execution engine with fine-grained scheduling"
+        "false": "Queries use traditional thread-per-fragment execution model"
+      note: "Has alias and show name configured on the @VarAttr annotation (L305)"
+      related_variables:
+        - "pipeline_dop"
+        - "max_pipeline_dop"
+        - "pipeline_profile_level"
+
+    - name: "pipeline_dop"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Degree of parallelism for pipeline execution. Controls the number of pipeline
+        drivers per fragment instance. When set to 0, the system auto-tunes based on
+        the number of CPU cores.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 337
+            context: "constant PIPELINE_DOP"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1481
+            context: "@VarAttr field pipelineDop = 0"
+        thrift_propagation: null
+      behavior:
+        zero: "Auto-tuned based on available CPU cores"
+        low_values: "Less parallelism per fragment, lower resource usage"
+        high_values: "More parallelism per fragment, higher throughput but more resource consumption"
+      related_variables:
+        - "max_pipeline_dop"
+        - "pipeline_sink_dop"
+        - "enable_runtime_adaptive_dop"
+
+    - name: "max_pipeline_dop"
+      type: Integer
+      default: 64
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum degree of parallelism for pipeline execution. Caps the pipeline DOP
+        regardless of auto-tuning or manual settings.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 338
+            context: "constant MAX_PIPELINE_DOP"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1521
+            context: "@VarAttr field maxPipelineDop = 64"
+        thrift_propagation: null
+      behavior:
+        low_values: "Tighter cap on parallelism"
+        high_values: "Allows more parallel drivers per fragment"
+      related_variables:
+        - "pipeline_dop"
+
+    - name: "pipeline_sink_dop"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Degree of parallelism for pipeline sink operators. Controls the number of
+        sink drivers. When set to 0, the system auto-tunes based on pipeline_dop.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 597
+            context: "constant PIPELINE_SINK_DOP"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1484
+            context: "@VarAttr field pipelineSinkDop = 0"
+        thrift_propagation: null
+      behavior:
+        zero: "Auto-tuned based on pipeline_dop"
+        positive: "Explicit sink parallelism override"
+      related_variables:
+        - "pipeline_dop"
+        - "enable_adaptive_sink_dop"
+
+    - name: "pipeline_profile_level"
+      type: Integer
+      default: 1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls the detail level of pipeline execution profiling.
+        Higher levels provide more detailed but more expensive profiling information.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 342
+            context: "constant PIPELINE_PROFILE_LEVEL"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1530
+            context: "@VarAttr field pipelineProfileLevel = 1"
+        thrift_propagation: null
+      behavior:
+        low_values: "Minimal profiling overhead"
+        high_values: "Detailed profiling with higher overhead"
+
+    - name: "enable_adaptive_sink_dop"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables adaptive adjustment of sink DOP at runtime. When enabled, the system
+        can dynamically tune sink parallelism based on workload characteristics.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 598
+            context: "constant ENABLE_ADAPTIVE_SINK_DOP"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1925
+            context: "@VarAttr field enableAdaptiveSinkDop = false"
+        thrift_propagation: null
+      related_variables:
+        - "pipeline_sink_dop"
+
+    - name: "enable_pipeline_event_scheduler"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables event-driven scheduling for the pipeline engine. When enabled, drivers
+        are scheduled based on events (data ready, IO complete) rather than polling.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 735
+            context: "constant ENABLE_PIPELINE_EVENT_SCHEDULER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3258
+            context: "@VarAttr field enablePipelineEventScheduler = true"
+        thrift_propagation: null
+      behavior:
+        "true": "Event-driven scheduling with lower latency for IO-bound queries"
+        "false": "Polling-based scheduling"
+
+  dop_and_adaptive:
+
+    - name: "enable_runtime_adaptive_dop"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables runtime adaptive degree of parallelism. When enabled, the system
+        can adjust DOP at runtime based on actual data distribution and workload,
+        potentially reducing resource waste for skewed queries.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 299
+            context: "constant ENABLE_RUNTIME_ADAPTIVE_DOP"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1131
+            context: "@VarAttr field enableRuntimeAdaptiveDop = false"
+        thrift_propagation: null
+      behavior:
+        "true": "DOP adjusts at runtime based on actual data volume"
+        "false": "DOP is fixed at planning time"
+      related_variables:
+        - "runtime_adaptive_dop_max_block_rows_per_driver_seq"
+        - "runtime_adaptive_dop_max_output_amplification_factor"
+        - "pipeline_dop"
+
+    - name: "runtime_adaptive_dop_max_block_rows_per_driver_seq"
+      type: Long
+      default: 16384
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of block rows per driver sequence for runtime adaptive DOP.
+        Controls the granularity of adaptive DOP adjustment decisions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 300
+            context: "constant ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1134
+            context: "@VarAttr field adaptiveDopMaxBlockRowsPerDriverSeq = 16384, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "enable_runtime_adaptive_dop"
+
+    - name: "runtime_adaptive_dop_max_output_amplification_factor"
+      type: Long
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum output amplification factor for runtime adaptive DOP.
+        Limits how much the output can be amplified relative to input when
+        adjusting DOP. 0 means no limit.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 302
+            context: "constant ADAPTIVE_DOP_MAX_OUTPUT_AMPLIFICATION_FACTOR"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1138
+            context: "@VarAttr field adaptiveDopMaxOutputAmplificationFactor = 0, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "enable_runtime_adaptive_dop"
+
+  fragment_parallelism:
+
+    - name: "parallel_fragment_exec_instance_num"
+      type: Integer
+      default: 1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Number of fragment instances to execute in parallel on each BE node.
+        Controls intra-node parallelism for query execution.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 225
+            context: "constant PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1475
+            context: "@VarAttr field parallelExecInstanceNum = 1"
+        thrift_propagation: null
+      behavior:
+        low_values: "Less parallelism per node, suitable for small queries"
+        high_values: "More parallelism per node, better for large scans"
+      related_variables:
+        - "max_parallel_scan_instance_num"
+        - "pipeline_dop"
+
+    - name: "max_parallel_scan_instance_num"
+      type: Integer
+      default: -1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of parallel scan instances per BE node. Controls the upper
+        bound of scan parallelism. -1 means no explicit limit (uses system default).
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 226
+            context: "constant MAX_PARALLEL_SCAN_INSTANCE_NUM"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1478
+            context: "@VarAttr field maxParallelScanInstanceNum = -1"
+        thrift_propagation: null
+      behavior:
+        negative: "No explicit limit, system decides"
+        positive: "Caps scan parallelism to specified value"
+      related_variables:
+        - "parallel_fragment_exec_instance_num"
+
+    - name: "parallel_exchange_instance_num"
+      type: Integer
+      default: -1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Number of exchange instances for data shuffling between fragments.
+        Controls the parallelism of data exchange operators. -1 means auto.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 266
+            context: "constant PARALLEL_EXCHANGE_INSTANCE_NUM"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1379
+            context: "@VarAttr field exchangeInstanceParallel = -1"
+        thrift_propagation: null
+      behavior:
+        negative: "Auto-determined by the optimizer"
+        positive: "Explicit number of exchange instances"
+      related_variables:
+        - "parallel_fragment_exec_instance_num"
+
+  group_execution:
+
+    - name: "enable_group_execution"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables group execution mode. Group execution partitions data into groups
+        and processes them sequentially, reducing memory consumption for large
+        aggregations and joins at the cost of some throughput.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 634
+            context: "constant ENABLE_GROUP_EXECUTION"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2014
+            context: "@VarAttr field enableGroupExecution = true"
+        thrift_propagation: null
+      behavior:
+        "true": "Large aggregations/joins use group-based execution to reduce memory"
+        "false": "All data processed in a single pass"
+      related_variables:
+        - "group_execution_group_scale"
+        - "group_execution_max_groups"
+        - "group_execution_min_scan_rows"
+
+    - name: "group_execution_group_scale"
+      type: Integer
+      default: 64
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Scale factor for the number of groups in group execution. Controls
+        the granularity of data partitioning within group execution.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 635
+            context: "constant GROUP_EXECUTION_GROUP_SCALE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2017
+            context: "@VarAttr field groupExecutionGroupScale = 64"
+        thrift_propagation: null
+      related_variables:
+        - "enable_group_execution"
+
+    - name: "group_execution_max_groups"
+      type: Integer
+      default: 128
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of groups for group execution. Caps the number of
+        data partitions created during group execution.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 636
+            context: "constant GROUP_EXECUTION_MAX_GROUPS"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2020
+            context: "@VarAttr field groupExecutionMaxGroups = 128"
+        thrift_propagation: null
+      related_variables:
+        - "enable_group_execution"
+
+    - name: "group_execution_min_scan_rows"
+      type: Long
+      default: 5000000
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Minimum number of scan rows required to trigger group execution.
+        If the estimated scan rows are below this threshold, group execution
+        is not used even if enabled.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 637
+            context: "constant GROUP_EXECUTION_MIN_SCAN_ROWS"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2023
+            context: "@VarAttr field groupExecutionMinScanRows = 5000000"
+        thrift_propagation: null
+      related_variables:
+        - "enable_group_execution"
+
+  scheduling:
+
+    - name: "choose_execute_instances_mode"
+      type: String
+      default: "LOCALITY"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Mode for choosing which BE instances execute a query fragment.
+        LOCALITY mode prefers BEs that hold local data replicas to minimize
+        network transfer.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 485
+            context: "constant CHOOSE_EXECUTE_INSTANCES_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3093
+            context: "@VarAttr field chooseExecuteInstancesMode = LOCALITY"
+        thrift_propagation: null
+      related_variables:
+        - "prefer_compute_node"
+        - "use_compute_nodes"
+        - "computation_fragment_scheduling_policy"
+
+    - name: "prefer_compute_node"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        When enabled, prefers scheduling computation fragments on compute nodes
+        rather than storage nodes (BEs). Useful in shared-data deployments.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 132
+            context: "constant PREFER_COMPUTE_NODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1158
+            context: "@VarAttr field preferComputeNode = false"
+        thrift_propagation: null
+      related_variables:
+        - "use_compute_nodes"
+        - "computation_fragment_scheduling_policy"
+
+    - name: "use_compute_nodes"
+      type: Integer
+      default: -1
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Number of compute nodes to use for query execution. -1 means use all
+        available compute nodes. Allows limiting the number of compute nodes
+        involved in a query.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 131
+            context: "constant USE_COMPUTE_NODES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1155
+            context: "@VarAttr field useComputeNodes = -1"
+        thrift_propagation: null
+      behavior:
+        negative: "Use all available compute nodes"
+        zero: "Do not use compute nodes"
+        positive: "Use up to N compute nodes"
+      related_variables:
+        - "prefer_compute_node"
+        - "computation_fragment_scheduling_policy"
+
+    - name: "computation_fragment_scheduling_policy"
+      type: String
+      default: "COMPUTE_NODES_ONLY"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Policy for scheduling computation-only fragments. Controls whether
+        computation fragments go to compute nodes only, all nodes, or other modes.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 135
+            context: "constant COMPUTATION_FRAGMENT_SCHEDULING_POLICY"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1161
+            context: "@VarAttr field computationFragmentSchedulingPolicy = COMPUTE_NODES_ONLY"
+        thrift_propagation: null
+      related_variables:
+        - "prefer_compute_node"
+        - "use_compute_nodes"
+
+    - name: "enable_phased_scheduler"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables phased scheduling for query execution. Phased scheduling
+        executes fragments in phases to reduce peak memory consumption.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 723
+            context: "constant ENABLE_PHASED_SCHEDULER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3252
+            context: "@VarAttr field enablePhasedScheduler = false"
+        thrift_propagation: null
+
+    - name: "enable_single_node_schedule"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables single-node scheduling where all fragments execute on a single BE.
+        Useful for small queries to avoid distribution overhead.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 725
+            context: "constant ENABLE_SINGLE_NODE_SCHEDULE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 3255
+            context: "@VarAttr field enableSingleNodeSchedule = false"
+        thrift_propagation: null
+
+    - name: "enable_query_queue"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables the query queue mechanism for admission control. When enabled,
+        queries may be queued when system resources are under pressure.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 641
+            context: "constant ENABLE_QUERY_QUEUE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2033
+            context: "@VarAttr field enableQueryQueue = true, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "exec_mode"
+
+    - name: "exec_mode"
+      type: String
+      default: "DEFAULT"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Execution mode for queries. Controls how queries are dispatched
+        to the execution engine.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 642
+            context: "constant EXEC_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2037
+            context: "@VarAttr field execMode = DEFAULT"
+        thrift_propagation: null
+      related_variables:
+        - "enable_query_queue"
+
+  parallelism_misc:
+
+    - name: "enable_parallel_merge"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables parallel merge for sorted results. When enabled, merge operations
+        for ORDER BY queries use multiple threads for better performance.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 639
+            context: "constant ENABLE_PARALLEL_MERGE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2026
+            context: "@VarAttr field enableParallelMerge = true"
+        thrift_propagation: null
+
+    - name: "enable_shared_scan"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables shared scan optimization where multiple operators can share
+        the same scan operator to avoid redundant reads of the same data.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 336
+            context: "constant ENABLE_SHARED_SCAN"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1214
+            context: "@VarAttr field enableSharedScan = false"
+        thrift_propagation: null
+
+    - name: "enable_local_shuffle_agg"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables local shuffle before aggregation. When enabled, data is locally
+        shuffled by grouping key before aggregation to improve data locality
+        and reduce hash table contention.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 319
+            context: "constant ENABLE_LOCAL_SHUFFLE_AGG"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1146
+            context: "@VarAttr field enableLocalShuffleAgg = true"
+        thrift_propagation: null
+
+    - name: "enable_per_bucket_optimize"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables per-bucket optimization for scan and aggregation. When the query
+        accesses bucketed tables and the aggregation/join key aligns with bucket
+        key, per-bucket scheduling avoids unnecessary shuffling.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 630
+            context: "constant ENABLE_PER_BUCKET_OPTIMIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2002
+            context: "@VarAttr field enablePerBucketOptimize = true"
+        thrift_propagation: null
+
+    - name: "enable_bucket_aware_execution_on_lake"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables bucket-aware execution for lake (shared-data) tables. When enabled,
+        the scheduler considers bucket boundaries when scheduling scan tasks on
+        lake storage to improve data locality.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 632
+            context: "constant ENABLE_BUCKET_AWARE_EXECUTION_ON_LAKE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2008
+            context: "@VarAttr field enableBucketAwareExecutionOnLake = true"
+        thrift_propagation: null
+
+    - name: "interleaving_group_size"
+      type: Integer
+      default: 10
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Size of interleaving groups for pipeline scheduling. Controls the
+        granularity of interleaved execution between different pipeline drivers.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 942
+            context: "constant INTERLEAVING_GROUP_SIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2059
+            context: "@VarAttr field interleavingGroupSize = 10"
+        thrift_propagation: null
+
+  pipeline_be_configs:
+
+    - name: "pipeline_exec_thread_pool_thread_num"
+      type: Int64
+      default: 0
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of threads in the pipeline execution thread pool. Controls how many
+        threads are available for executing pipeline drivers. 0 means auto-tuned
+        based on the number of CPU cores.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 989
+            context: "CONF_Int64 pipeline_exec_thread_pool_thread_num = 0"
+      behavior:
+        zero: "Auto-tuned to number of CPU cores"
+        positive: "Explicit thread pool size"
+      related_variables:
+        - "pipeline_scan_thread_pool_thread_num"
+        - "pipeline_prepare_thread_pool_thread_num"
+
+    - name: "pipeline_scan_thread_pool_thread_num"
+      type: Int64
+      default: 0
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of threads in the pipeline scan thread pool for local scan I/O.
+        0 means auto-tuned based on the number of CPU cores.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 984
+            context: "CONF_Int64 pipeline_scan_thread_pool_thread_num = 0"
+      behavior:
+        zero: "Auto-tuned to number of CPU cores"
+        positive: "Explicit scan thread pool size"
+      related_variables:
+        - "pipeline_exec_thread_pool_thread_num"
+        - "pipeline_connector_scan_thread_num_per_cpu"
+
+    - name: "pipeline_connector_scan_thread_num_per_cpu"
+      type: Double
+      default: 8
+      scope: "BE config"
+      mutable: true
+      description: >
+        Number of connector scan threads per CPU core. Controls thread pool sizing
+        for external data source scans (Hive, Iceberg, etc.). Higher values allow
+        more concurrent external IO operations.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 985
+            context: "CONF_mDouble pipeline_connector_scan_thread_num_per_cpu = 8"
+      behavior:
+        low_values: "Fewer threads for external scans, less IO parallelism"
+        high_values: "More threads for external scans, handles high-latency sources better"
+
+    - name: "pipeline_prepare_thread_pool_thread_num"
+      type: Int64
+      default: 0
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of threads in the pipeline prepare thread pool. Used for preparing
+        pipeline drivers before execution. 0 means auto-tuned.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 994
+            context: "CONF_Int64 pipeline_prepare_thread_pool_thread_num = 0"
+
+    - name: "pipeline_sink_io_thread_pool_thread_num"
+      type: Int64
+      default: 0
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of threads in the pipeline sink IO thread pool. Handles IO
+        operations for sink operators (writing results, sending data). 0 means auto-tuned.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 997
+            context: "CONF_Int64 pipeline_sink_io_thread_pool_thread_num = 0"
+
+    - name: "pipeline_sink_buffer_size"
+      type: Int64
+      default: 64
+      scope: "BE config"
+      mutable: false
+      description: >
+        Size of the buffer for pipeline sink operators. Controls how many chunks
+        can be buffered in the sink before backpressure is applied.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1000
+            context: "CONF_Int64 pipeline_sink_buffer_size = 64"
+
+    - name: "pipeline_sink_brpc_dop"
+      type: Int64
+      default: 64
+      scope: "BE config"
+      mutable: false
+      description: >
+        Degree of parallelism for BRPC-based data sink. Controls how many
+        concurrent BRPC requests can be in-flight for data exchange.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1002
+            context: "CONF_Int64 pipeline_sink_brpc_dop = 64"
+
+    - name: "pipeline_max_num_drivers_per_exec_thread"
+      type: Int64
+      default: 10240
+      scope: "BE config"
+      mutable: false
+      description: >
+        Maximum number of pipeline drivers per execution thread. Limits the number
+        of concurrent drivers that can be assigned to a single execution thread.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1005
+            context: "CONF_Int64 pipeline_max_num_drivers_per_exec_thread = 10240"
+
+    - name: "pipeline_driver_queue_level_time_slice_base_ns"
+      type: Int64
+      default: 200000000
+      scope: "BE config"
+      mutable: false
+      description: >
+        Base time slice in nanoseconds for the multi-level feedback queue used
+        in pipeline driver scheduling. Lower levels get shorter time slices.
+        Default is 200ms.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 1014
+            context: "CONF_Int64 pipeline_driver_queue_level_time_slice_base_ns = 200000000"
+
+    - name: "vector_chunk_size"
+      type: Int32
+      default: 4096
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of rows per chunk in the vectorized execution engine. Controls
+        the batch size for vectorized processing. Larger values improve throughput
+        for scan-heavy queries; smaller values reduce latency.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 893
+            context: "CONF_Int32 vector_chunk_size = 4096"
+      behavior:
+        low_values: "Smaller batches, lower latency, more function-call overhead"
+        high_values: "Larger batches, higher throughput, better SIMD utilization"
+
+  worker_thread_be_configs:
+
+    - name: "be_service_threads"
+      type: Int32
+      default: 64
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of threads for the BE BRPC service. Handles incoming RPC requests
+        from FE and other BEs for query execution, data loading, etc.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 240
+            context: "CONF_Int32 be_service_threads = 64"
+
+    - name: "scanner_thread_pool_thread_num"
+      type: Int32
+      default: 48
+      scope: "BE config"
+      mutable: true
+      description: >
+        Number of threads in the scanner thread pool. Controls the parallelism
+        of data scanning operations (used by the non-pipeline execution engine
+        and some pipeline scan operators).
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 269
+            context: "CONF_mInt32 scanner_thread_pool_thread_num = 48"
+      behavior:
+        low_values: "Less scan parallelism, lower CPU and IO usage"
+        high_values: "More scan parallelism, better scan throughput"
+
+    - name: "fragment_pool_thread_num_min"
+      type: Int32
+      default: 64
+      scope: "BE config"
+      mutable: false
+      description: >
+        Minimum number of threads in the fragment execution pool.
+        Ensures a baseline number of threads are always available
+        for fragment execution.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 639
+            context: "CONF_Int32 fragment_pool_thread_num_min = 64"
+      related_variables:
+        - "fragment_pool_thread_num_max"
+
+    - name: "fragment_pool_thread_num_max"
+      type: Int32
+      default: 4096
+      scope: "BE config"
+      mutable: false
+      description: >
+        Maximum number of threads in the fragment execution pool.
+        Caps the thread count to prevent excessive resource consumption.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 640
+            context: "CONF_Int32 fragment_pool_thread_num_max = 4096"
+      related_variables:
+        - "fragment_pool_thread_num_min"
+
+    - name: "brpc_num_threads"
+      type: Int32
+      default: -1
+      scope: "BE config"
+      mutable: false
+      description: >
+        Number of bthread workers for the BRPC server. -1 means auto-tuned
+        by BRPC based on system resources. Controls the concurrency of
+        RPC handling.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 50
+            context: "CONF_Int32 brpc_num_threads = -1"
+      behavior:
+        negative: "Auto-tuned by BRPC library"
+        positive: "Explicit thread count for BRPC workers"
+
+    - name: "number_tablet_writer_threads"
+      type: Int32
+      default: 0
+      scope: "BE config"
+      mutable: true
+      description: >
+        Number of threads for tablet writer operations (data ingestion).
+        0 means auto-tuned based on system resources. Used for write-heavy
+        workloads like data loading and compaction.
+      code_references:
+        definition:
+          - file: "be/src/common/config.h"
+            line: 541
+            context: "CONF_mInt32 number_tablet_writer_threads = 0"
+      behavior:
+        zero: "Auto-tuned based on system resources"
+        positive: "Explicit thread count for tablet writers"

--- a/param-docs/07_materialized_views.yml
+++ b/param-docs/07_materialized_views.yml
@@ -1,0 +1,760 @@
+# StarRocks Parameter Dictionary - Materialized Views
+# MV rewrite, planning, refresh, text match, view-delta, CBO integration
+
+materialized_views:
+
+  mv_rewrite:
+
+    - name: "enable_materialized_view_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Master switch for materialized view query rewrite. When enabled, the optimizer
+        considers rewriting queries to use materialized views for acceleration.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 688
+            context: "constant ENABLE_MATERIALIZED_VIEW_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2643
+            context: "@VarAttr field enableMaterializedViewRewrite = true"
+        thrift_propagation: null
+      behavior:
+        "true": "Optimizer attempts to rewrite queries using available MVs"
+        "false": "No MV-based query rewrite is attempted"
+      related_variables:
+        - "enable_sync_materialized_view_rewrite"
+        - "enable_materialized_view_for_insert"
+        - "materialized_view_rewrite_mode"
+
+    - name: "enable_sync_materialized_view_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables rewrite using synchronous (rollup) materialized views. Synchronous MVs
+        are automatically maintained during data loading and are always consistent with
+        the base table.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 784
+            context: "constant ENABLE_SYNC_MATERIALIZED_VIEW_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2652
+            context: "@VarAttr field enableSyncMaterializedViewRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_rewrite"
+
+    - name: "enable_cbo_based_mv_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables materialized view rewrite in the CBO (cost-based optimizer) phase.
+        When true, the optimizer tries to use MVs for rewrite in both RBO and CBO phases.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 816
+            context: "constant ENABLE_CBO_BASED_MV_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2744
+            context: "@VarAttr field enableCBOBasedMVRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "enable_cbo_view_based_mv_rewrite"
+        - "enable_materialized_view_rewrite"
+
+    - name: "enable_cbo_view_based_mv_rewrite"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables CBO-phase view-based materialized view rewrite. When enabled, the CBO
+        considers rewriting queries through view definitions that match MV definitions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 815
+            context: "constant ENABLE_CBO_VIEW_BASED_MV_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2739
+            context: "@VarAttr field enableCBOViewBasedMvRewrite = false"
+        thrift_propagation: null
+      related_variables:
+        - "enable_cbo_based_mv_rewrite"
+        - "enable_view_based_mv_rewrite"
+
+    - name: "materialized_view_union_rewrite_mode"
+      type: Integer
+      default: 0
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls the union rewrite mode for materialized views. See
+        MaterializedViewUnionRewriteMode for mode definitions.
+        Mode 0 is the default behavior.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 690
+            context: "constant MATERIALIZED_VIEW_UNION_REWRITE_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2661
+            context: "@VarAttr field materializedViewUnionRewriteMode = 0"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_union_rewrite"
+        - "enable_materialized_view_transparent_union_rewrite"
+
+    - name: "optimizer_materialized_view_timelimit"
+      type: Long
+      default: 1000
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Time limit in milliseconds for materialized view rewrite during optimization.
+        If MV rewrite takes longer than this, it is abandoned and the original plan
+        is used instead.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 399
+            context: "constant OPTIMIZER_MATERIALIZED_VIEW_TIMELIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1750
+            context: "@VarAttr field optimizerMaterializedViewTimelimit = 1000"
+        thrift_propagation: null
+      behavior:
+        low_values: "Less time for MV rewrite, may miss complex rewrites"
+        high_values: "More time for MV rewrite, may slow down planning"
+
+    - name: "cbo_materialized_view_rewrite_rule_output_limit"
+      type: Integer
+      default: 3
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of MV rewrite outputs per rule for an OptExpression.
+        Limits how many alternative MV-based plans a single rewrite rule can produce.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 400
+            context: "constant CBO_MATERIALIZED_VIEW_REWRITE_RULE_OUTPUT_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2762
+            context: "@VarAttr field cboMaterializedViewRewriteRuleOutputLimit = 3, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "cbo_materialized_view_rewrite_candidate_limit"
+        - "cbo_materialized_view_rewrite_related_mvs_limit"
+
+    - name: "cbo_materialized_view_rewrite_candidate_limit"
+      type: Integer
+      default: 12
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of MV candidates considered per rewrite rule for an OptExpression.
+        Limits the search space of MV rewrite to control planning time.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 402
+            context: "constant CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2768
+            context: "@VarAttr field cboMaterializedViewRewriteCandidateLimit = 12, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "cbo_materialized_view_rewrite_rule_output_limit"
+        - "cbo_materialized_view_rewrite_related_mvs_limit"
+
+    - name: "cbo_materialized_view_rewrite_related_mvs_limit"
+      type: Integer
+      default: 16
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of related materialized views considered for rewriting a query.
+        Limits the total number of MVs the optimizer evaluates for a single query.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 404
+            context: "constant CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2774
+            context: "@VarAttr field cboMaterializedViewRewriteRelatedMVsLimit = 16, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "cbo_materialized_view_rewrite_rule_output_limit"
+        - "cbo_materialized_view_rewrite_candidate_limit"
+
+    - name: "materialized_view_join_same_table_permutation_limit"
+      type: Integer
+      default: 5
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Maximum number of join permutations to consider when the same table appears
+        multiple times in an MV join. Limits combinatorial explosion in self-join
+        MV matching.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 795
+            context: "constant MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2708
+            context: "@VarAttr field materializedViewJoinSameTablePermutationLimit = 5, INVISIBLE"
+        thrift_propagation: null
+
+  mv_planning:
+
+    - name: "enable_mv_planner"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables the dedicated MV planner for materialized view refresh planning.
+        The MV planner optimizes refresh operations specifically for MVs.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 309
+            context: "constant ENABLE_MV_PLANNER"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1141
+            context: "@VarAttr field enableMVPlanner = false"
+        thrift_propagation: null
+
+    - name: "enable_incremental_mv"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables incremental refresh for materialized views. When enabled, only the
+        changed partitions or data are refreshed rather than the entire MV.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 310
+            context: "constant ENABLE_INCREMENTAL_REFRESH_MV"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 1143
+            context: "@VarAttr field enableIncrementalRefreshMV = false"
+        thrift_propagation: null
+
+    - name: "enable_materialized_view_for_insert"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables materialized view rewrite for INSERT statements. When enabled,
+        the optimizer can use MVs to accelerate INSERT ... SELECT queries.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 782
+            context: "constant ENABLE_MATERIALIZED_VIEW_REWRITE_FOR_INSERT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2649
+            context: "@VarAttr field enableMaterializedViewRewriteForInsert = false"
+        thrift_propagation: null
+
+    - name: "query_excluding_mv_names"
+      type: String
+      default: ""
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Comma-separated list of materialized view names to exclude from query rewrite.
+        The optimizer will not consider these MVs when rewriting queries.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 803
+            context: "constant QUERY_EXCLUDING_MV_NAMES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2777
+            context: "@VarAttr field queryExcludingMVNames = '', INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "query_including_mv_names"
+
+    - name: "query_including_mv_names"
+      type: String
+      default: ""
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Comma-separated list of materialized view names to include for query rewrite.
+        When set, only these MVs are considered for rewrite. Empty means all MVs
+        are considered.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 804
+            context: "constant QUERY_INCLUDING_MV_NAMES"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2780
+            context: "@VarAttr field queryIncludingMVNames = '', INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "query_excluding_mv_names"
+
+  mv_union_rewrite:
+
+    - name: "enable_materialized_view_union_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables union-based materialized view rewrite. When the MV only covers
+        a subset of the data (e.g., partial partitions), union rewrite combines
+        the MV scan with a base table scan for the remaining data.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 689
+            context: "constant ENABLE_MATERIALIZED_VIEW_UNION_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2655
+            context: "@VarAttr field enableMaterializedViewUnionRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "materialized_view_union_rewrite_mode"
+        - "enable_materialized_view_transparent_union_rewrite"
+
+    - name: "enable_materialized_view_transparent_union_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables transparent union rewrite for materialized views. Treats the MV
+        as always-consistent and performs union rewrite without consistency checking,
+        useful for near-real-time scenarios where slight staleness is acceptable.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 691
+            context: "constant ENABLE_MATERIALIZED_VIEW_TRANSPARENT_UNION_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2668
+            context: "@VarAttr field enableMaterializedViewTransparentUnionRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_union_rewrite"
+
+  mv_partition_compensate:
+
+    - name: "enable_materialized_view_rewrite_partition_compensate"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables partition predicate compensation in MV rewrite. When enabled,
+        extra predicates are added to ensure data consistency between MV and base
+        table partitions. Disabling can allow more rewrite cases but may lose
+        consistency guarantees.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 694
+            context: "constant ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2677
+            context: "@VarAttr field enableMaterializedViewRewritePartitionCompensate = true, INVISIBLE"
+        thrift_propagation: null
+
+  mv_agg_pushdown:
+
+    - name: "enable_materialized_view_agg_pushdown_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables aggregate pushdown rewrite with materialized views. When enabled,
+        aggregations can be pushed down and computed using MV pre-aggregated data.
+        This is the alias/show name; the actual variable is the V2 variant.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 698
+            context: "constant ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE_V2"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2683
+            context: "@VarAttr field enableMaterializedViewPushDownRewrite = true (alias: enable_materialized_view_agg_pushdown_rewrite)"
+        thrift_propagation: null
+      note: "V2 variable with alias/show name ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE"
+      related_variables:
+        - "enable_materialized_view_timeseries_agg_pushdown_rewrite"
+
+    - name: "enable_materialized_view_timeseries_agg_pushdown_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables time-series aggregate pushdown rewrite with materialized views.
+        Optimizes time-series queries by pushing time-based aggregations to MVs.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 700
+            context: "constant ENABLE_MATERIALIZED_VIEW_TIMESERIES_AGG_PUSHDOWN_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2687
+            context: "@VarAttr field enableMaterializedViewTimeSeriesPushDownRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_agg_pushdown_rewrite"
+
+  mv_text_match:
+
+    - name: "enable_materialized_view_text_match_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables text-based query matching for MV rewrite. The optimizer compares
+        query text (or subquery text) against MV definitions to find rewrite
+        opportunities without full logical equivalence checking.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 703
+            context: "constant ENABLE_MATERIALIZED_VIEW_TEXT_MATCH_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2693
+            context: "@VarAttr field enableMaterializedViewTextMatchRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "materialized_view_subquery_text_match_max_count"
+
+    - name: "materialized_view_subquery_text_match_max_count"
+      type: Integer
+      default: 4
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum number of subquery text matches to consider during MV text-based
+        rewrite. Limits the number of subquery-level text matching attempts.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 705
+            context: "constant MATERIALIZED_VIEW_SUBQUERY_TEXT_MATCH_MAX_COUNT"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2696
+            context: "@VarAttr field materializedViewSubQueryTextMatchMaxCount = 4"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_text_match_rewrite"
+
+  mv_view_delta:
+
+    - name: "enable_materialized_view_view_delta_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables view-delta rewrite for materialized views. View-delta rewrite handles
+        cases where the query has fewer joins than the MV definition by compensating
+        with additional join predicates.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 788
+            context: "constant ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2699
+            context: "@VarAttr field enableMaterializedViewViewDeltaRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_single_table_view_delta_rewrite"
+
+    - name: "enable_materialized_view_single_table_view_delta_rewrite"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables view-delta compensation for single-table queries against multi-table MVs.
+        When enabled, single-table queries can be rewritten using join-based MVs
+        where the extra joins are compensated. The plan is chosen by cost.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 798
+            context: "constant ENABLE_MATERIALIZED_VIEW_SINGLE_TABLE_VIEW_DELTA_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2719
+            context: "@VarAttr field enableMaterializedViewSingleTableViewDeltaRewrite = false, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_view_delta_rewrite"
+
+  mv_multi_stage_and_nesting:
+
+    - name: "enable_materialized_view_multi_stages_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables multi-stage materialized view rewrite. Allows the optimizer to
+        apply MV rewrite in multiple stages of query optimization.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 790
+            context: "constant ENABLE_MATERIALIZED_VIEW_MULTI_STAGES_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2702
+            context: "@VarAttr field enableMaterializedViewMultiStagesRewrite = true"
+        thrift_propagation: null
+
+    - name: "nested_mv_rewrite_max_level"
+      type: Integer
+      default: 3
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum nesting level for materialized view rewrite. Controls how many
+        levels of MV-on-MV rewrites the optimizer will attempt. Higher values
+        allow deeper chains of nested MV rewrites.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 687
+            context: "constant NESTED_MV_REWRITE_MAX_LEVEL"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2640
+            context: "@VarAttr field nestedMvRewriteMaxLevel = 3"
+        thrift_propagation: null
+
+    - name: "materialized_view_max_relation_mapping_size"
+      type: Integer
+      default: 10
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Maximum size of relation mapping during MV rewrite. Limits the number
+        of table-to-table mappings considered when matching query tables to
+        MV tables.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 792
+            context: "constant MATERIALIZED_VIEW_MAX_RELATION_MAPPING_SIZE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2705
+            context: "@VarAttr field materializedViewMaxRelationMappingSize = 10"
+        thrift_propagation: null
+
+  mv_rewrite_mode_and_strategy:
+
+    - name: "materialized_view_rewrite_mode"
+      type: String
+      default: "MODE_DEFAULT"
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Controls the materialized view rewrite mode. See MaterializedViewRewriteMode
+        for available modes. MODE_DEFAULT applies standard rewrite behavior.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 780
+            context: "constant MATERIALIZED_VIEW_REWRITE_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2711
+            context: "@VarAttr field materializedViewRewriteMode = MaterializedViewRewriteMode.MODE_DEFAULT"
+        thrift_propagation: null
+
+    - name: "enable_materialized_view_rewrite_greedy_mode"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables greedy mode for MV rewrite to reduce optimizer time. In greedy mode,
+        plan caching is used when possible, and the max plan tree is used for view-delta
+        rewrites to avoid combinatorial explosion.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 805
+            context: "constant ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2725
+            context: "@VarAttr field enableMaterializedViewRewriteGreedyMode = false"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_plan_cache"
+
+    - name: "enable_force_rule_based_mv_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables forced rule-based MV rewrite. When enabled, rule-based MV
+        rewrite is always attempted before CBO-based rewrite.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 785
+            context: "constant ENABLE_FORCE_RULE_BASED_MV_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2690
+            context: "@VarAttr field enableForceRuleBasedMvRewrite = true"
+        thrift_propagation: null
+
+    - name: "enable_view_based_mv_rewrite"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables view-based materialized view rewrite. Allows the optimizer to
+        match queries against MVs through SQL view definitions.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 813
+            context: "constant ENABLE_VIEW_BASED_MV_REWRITE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2736
+            context: "@VarAttr field enableViewBasedMvRewrite = true"
+        thrift_propagation: null
+      related_variables:
+        - "enable_cbo_view_based_mv_rewrite"
+
+  mv_caching_and_concurrency:
+
+    - name: "enable_materialized_view_plan_cache"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables plan caching for materialized view rewrite. Cached MV plan
+        contexts are reused to reduce the cost of repeated MV rewrite operations.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 808
+            context: "constant ENABLE_MATERIALIZED_VIEW_PLAN_CACHE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2729
+            context: "@VarAttr field enableMaterializedViewPlanCache = true, INVISIBLE"
+        thrift_propagation: null
+      related_variables:
+        - "enable_materialized_view_rewrite_greedy_mode"
+
+    - name: "enable_materialized_view_concurrent_prepare"
+      type: Boolean
+      default: true
+      scope: "FE session variable"
+      mutable: true
+      description: >
+        Enables concurrent preparation of MV rewrite candidates. When enabled,
+        multiple MV candidates are prepared in parallel to reduce total MV rewrite
+        latency.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 810
+            context: "constant ENABLE_MATERIALIZED_VIEW_CONCURRENT_PREPARE"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2733
+            context: "@VarAttr field enableMaterializedViewConcurrentPrepare = true"
+        thrift_propagation: null
+
+  mv_refresh:
+
+    - name: "enable_ivm_refresh"
+      type: Boolean
+      default: false
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Enables incremental view maintenance (IVM) refresh for materialized views.
+        IVM tracks changes to base tables and applies only delta changes to the MV
+        during refresh.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 818
+            context: "constant ENABLE_IVM_REFRESH"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2750
+            context: "@VarAttr field enableIVMRefresh = false, INVISIBLE"
+        thrift_propagation: null
+
+    - name: "tvr_target_mvid"
+      type: String
+      default: ""
+      scope: "FE session variable"
+      mutable: true
+      flag: INVISIBLE
+      description: >
+        Target MV ID for time-varying relation (TVR) based incremental computation.
+        Used internally for IVM refresh scheduling.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 819
+            context: "constant TVR_TARGET_MVID"
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 2747
+            context: "@VarAttr field tvrTargetMvId = '', INVISIBLE"
+        thrift_propagation: null
+
+  mv_deprecated:
+
+    - name: "analyze_mv"
+      type: String
+      default: ""
+      scope: "FE session variable"
+      mutable: true
+      deprecated: true
+      description: >
+        Deprecated. Previously used to trigger analysis for a specific materialized view.
+      code_references:
+        definition:
+          - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+            line: 802
+            context: "constant ANALYZE_FOR_MV (deprecated)"
+        thrift_propagation: null

--- a/param-docs/08_external_catalogs.yml
+++ b/param-docs/08_external_catalogs.yml
@@ -1,0 +1,1411 @@
+# =============================================================================
+# StarRocks External Catalogs & Connector Parameters
+# Source: fe/.../qe/SessionVariable.java, be/src/common/config.h
+# =============================================================================
+
+session_variables:
+
+  - name: "catalog"
+    type: String
+    default: "default_catalog"
+    scope: "session_only"
+    mutable: true
+    description: >
+      The current catalog context for the session. Determines which catalog
+      (internal or external) is used for unqualified table references.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 211
+          context: "public static final String CATALOG = \"catalog\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2538
+          context: "@VariableMgr.VarAttr(name = CATALOG, flag = VariableMgr.SESSION_ONLY) private String catalog = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME"
+      thrift_propagation: null
+
+  - name: "plan_mode"
+    type: String
+    default: "auto"
+    scope: "session"
+    mutable: true
+    description: >
+      Controls the planning mode for queries involving external catalogs.
+      Options: auto, local, dual. Affects how scan ranges are planned for
+      external connector tables.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 551
+          context: "public static final String PLAN_MODE = \"plan_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3049
+          context: "@VarAttr(name = PLAN_MODE) private String planMode = PlanMode.AUTO.modeName()"
+      thrift_propagation: null
+
+  - name: "warehouse"
+    type: String
+    default: "default_warehouse"
+    scope: "session_only"
+    mutable: true
+    description: >
+      The warehouse name for the current session. Used in shared-data
+      deployments to route queries to specific compute resources.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 921
+          context: "public static final String WAREHOUSE_NAME = \"warehouse\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2899
+          context: "@VariableMgr.VarAttr(name = WAREHOUSE_NAME, flag = VariableMgr.SESSION_ONLY) private String warehouseName = WarehouseManager.DEFAULT_WAREHOUSE_NAME"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Hive parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_hive_column_stats"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use column statistics from Hive Metastore for cost-based
+      query optimization on Hive external tables.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 553
+          context: "public static final String ENABLE_HIVE_COLUMN_STATS = \"enable_hive_column_stats\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1910
+          context: "@VariableMgr.VarAttr(name = ENABLE_HIVE_COLUMN_STATS) private boolean enableHiveColumnStats = true"
+      thrift_propagation: null
+
+  - name: "enable_write_hive_external_table"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Enables writing data to Hive external tables. When false, INSERT
+      operations to Hive tables are blocked.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 555
+          context: "public static final String ENABLE_WRITE_HIVE_EXTERNAL_TABLE = \"enable_write_hive_external_table\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1913
+          context: "@VariableMgr.VarAttr(name = ENABLE_WRITE_HIVE_EXTERNAL_TABLE) private boolean enableWriteHiveExternalTable = false"
+      thrift_propagation: null
+
+  - name: "enable_hive_metadata_cache_with_insert"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to update Hive metadata cache when inserting data into
+      Hive external tables, avoiding stale cache after writes.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 557
+          context: "public static final String ENABLE_HIVE_METADATA_CACHE_WITH_INSERT = \"enable_hive_metadata_cache_with_insert\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1916
+          context: "@VariableMgr.VarAttr(name = ENABLE_HIVE_METADATA_CACHE_WITH_INSERT) private boolean enableHiveMetadataCacheWithInsert = false"
+      thrift_propagation: null
+
+  - name: "hive_partition_stats_sample_size"
+    type: int
+    default: 3000
+    scope: "session"
+    mutable: true
+    description: >
+      The number of partitions to sample when estimating partition-level
+      statistics for Hive tables. Higher values improve accuracy but
+      increase metadata collection latency.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 564
+          context: "public static final String HIVE_PARTITION_STATS_SAMPLE_SIZE = \"hive_partition_stats_sample_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1919
+          context: "@VariableMgr.VarAttr(name = HIVE_PARTITION_STATS_SAMPLE_SIZE) private int hivePartitionStatsSampleSize = 3000"
+      thrift_propagation: null
+
+  - name: "hive_temp_staging_dir"
+    type: String
+    default: "/tmp/starrocks"
+    scope: "session"
+    mutable: true
+    description: >
+      Temporary staging directory on HDFS/object storage used for
+      writing data to Hive tables before committing.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 931
+          context: "public static final String HIVE_TEMP_STAGING_DIR = \"hive_temp_staging_dir\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2910
+          context: "@VarAttr(name = HIVE_TEMP_STAGING_DIR) private String hiveTempStagingDir = \"/tmp/starrocks\""
+      thrift_propagation: null
+
+  - name: "allow_hive_without_partition_filter"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to allow queries on partitioned Hive tables without a
+      partition filter predicate. When false, queries without partition
+      pruning predicates are rejected.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 952
+          context: "public static final String ALLOW_HIVE_WITHOUT_PARTITION_FILTER = \"allow_hive_without_partition_filter\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2916
+          context: "@VarAttr(name = ALLOW_HIVE_WITHOUT_PARTITION_FILTER) private boolean allowHiveWithoutPartitionFilter = true"
+      thrift_propagation: null
+
+  - name: "scan_hive_partition_num_limit"
+    type: int
+    default: 0
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum number of partitions scanned in a single lake/Hive table
+      scan. 0 means no limit. Alias for scan_lake_partition_num_limit.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 954
+          context: "public static final String SCAN_HIVE_PARTITION_NUM_LIMIT = \"scan_hive_partition_num_limit\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2924
+          context: "@VarAttr(name = SCAN_LAKE_PARTITION_NUM_LIMIT, alias = SCAN_HIVE_PARTITION_NUM_LIMIT) private int scanLakePartitionNumLimit = 0"
+      thrift_propagation: null
+
+  - name: "force_schedule_local"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Force scheduling scan tasks to local BE nodes for Hive external
+      tables using HybridBackendSelector. Improves data locality.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 384
+          context: "public static final String FORCE_SCHEDULE_LOCAL = \"force_schedule_local\""
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Iceberg parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_prune_iceberg_manifest"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to prune Iceberg manifest files during query planning.
+      Reduces I/O by skipping irrelevant manifests based on partition
+      predicates.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 535
+          context: "public static final String ENABLE_PRUNE_ICEBERG_MANIFEST = \"enable_prune_iceberg_manifest\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3025
+          context: "@VarAttr(name = ENABLE_PRUNE_ICEBERG_MANIFEST) private boolean enablePruneIcebergManifest = true"
+      thrift_propagation: null
+
+  - name: "enable_read_iceberg_puffin_ndv"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to read NDV (number of distinct values) statistics from
+      Iceberg Puffin files for cost-based optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 537
+          context: "public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = \"enable_read_iceberg_puffin_ndv\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3028
+          context: "@VarAttr(name = ENABLE_READ_ICEBERG_PUFFIN_NDV) private boolean enableReadIcebergPuffinNdv = true"
+      thrift_propagation: null
+
+  - name: "enable_iceberg_column_statistics"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use Iceberg column-level statistics for cost-based
+      query optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 539
+          context: "public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = \"enable_iceberg_column_statistics\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3031
+          context: "@VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS) private boolean enableIcebergColumnStatistics = false"
+      thrift_propagation: null
+
+  - name: "enable_read_iceberg_equality_delete_with_partition_evolution"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to support reading Iceberg equality delete files when
+      partition evolution has occurred. May incur extra I/O overhead.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 540
+          context: "public static final String ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION"
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3034
+          context: "@VarAttr(name = ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION) private boolean enableReadIcebergEqDeleteWithPartitionEvolution = false"
+      thrift_propagation: null
+
+  - name: "enable_iceberg_identity_column_optimize"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Enables optimization that uses identity partition columns in
+      Iceberg tables to skip unnecessary data reads.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 710
+          context: "public static final String ENABLE_ICEBERG_IDENTITY_COLUMN_OPTIMIZE = \"enable_iceberg_identity_column_optimize\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3228
+          context: "@VarAttr(name = ENABLE_ICEBERG_IDENTITY_COLUMN_OPTIMIZE) private boolean enableIcebergIdentityColumnOptimize = true"
+      thrift_propagation: null
+
+  - name: "enable_iceberg_sink_global_shuffle"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Deprecated: Use connector_sink_shuffle_mode instead. Whether to
+      enable global shuffle for Iceberg table sink operations.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 574
+          context: "public static final String ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE = \"enable_iceberg_sink_global_shuffle\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1492
+          context: "@VariableMgr.VarAttr(name = ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE) private boolean enableIcebergSinkGlobalShuffle = false"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Delta Lake parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_delta_lake_column_statistics"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use Delta Lake column-level statistics for cost-based
+      query optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 542
+          context: "public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = \"enable_delta_lake_column_statistics\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3037
+          context: "@VarAttr(name = ENABLE_DELTA_LAKE_COLUMN_STATISTICS) private boolean enableDeltaLakeColumnStatistics = false"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Paimon parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_paimon_column_statistics"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use Paimon column-level statistics for cost-based
+      query optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 549
+          context: "public static final String ENABLE_PAIMON_COLUMN_STATISTICS = \"enable_paimon_column_statistics\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3046
+          context: "@VarAttr(name = ENABLE_PAIMON_COLUMN_STATISTICS) private boolean enablePaimonColumnStatistics = false"
+      thrift_propagation: null
+
+  - name: "paimon_force_jni_reader"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Force using JNI reader for Paimon tables instead of native C++
+      reader. Useful for compatibility when native reader has issues.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 662
+          context: "public static final String PAIMON_FORCE_JNI_READER = \"paimon_force_jni_reader\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2619
+          context: "@VariableMgr.VarAttr(name = PAIMON_FORCE_JNI_READER) private boolean paimonForceJNIReader = false"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Hudi parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "hudi_mor_force_jni_reader"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Force using JNI reader for Hudi MOR (Merge on Read) tables instead
+      of native C++ reader.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 661
+          context: "public static final String HUDI_MOR_FORCE_JNI_READER = \"hudi_mor_force_jni_reader\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2616
+          context: "@VariableMgr.VarAttr(name = HUDI_MOR_FORCE_JNI_READER) private boolean hudiMORForceJNIReader = false"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Connector I/O and scan parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "connector_io_tasks_per_scan_operator"
+    type: int
+    default: 16
+    scope: "session"
+    mutable: true
+    description: >
+      Number of I/O tasks per scan operator for external connector tables.
+      Controls parallelism of data reading from external sources.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 665
+          context: "public static final String CONNECTOR_IO_TASKS_PER_SCAN_OPERATOR = \"connector_io_tasks_per_scan_operator\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2570
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_IO_TASKS_PER_SCAN_OPERATOR) private int connectorIoTasksPerScanOperator = 16"
+      thrift_propagation: null
+
+  - name: "enable_connector_adaptive_io_tasks"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to adaptively adjust the number of I/O tasks for connector
+      scans based on I/O latency.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 666
+          context: "public static final String ENABLE_CONNECTOR_ADAPTIVE_IO_TASKS = \"enable_connector_adaptive_io_tasks\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2573
+          context: "@VariableMgr.VarAttr(name = ENABLE_CONNECTOR_ADAPTIVE_IO_TASKS) private boolean enableConnectorAdaptiveIoTasks = true"
+      thrift_propagation: null
+
+  - name: "enable_connector_split_io_tasks"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to split large I/O tasks into smaller chunks for connector
+      scans, improving parallelism on large files.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 673
+          context: "public static final String ENABLE_CONNECTOR_SPLIT_IO_TASKS = \"enable_connector_split_io_tasks\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2576
+          context: "@VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SPLIT_IO_TASKS) private boolean enableConnectorSplitIoTasks = true"
+      thrift_propagation: null
+
+  - name: "connector_io_tasks_slow_io_latency_ms"
+    type: int
+    default: 50
+    scope: "session"
+    mutable: true
+    description: >
+      Latency threshold in milliseconds to classify I/O as slow for
+      adaptive I/O task adjustment. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 667
+          context: "public static final String CONNECTOR_IO_TASKS_SLOW_IO_LATENCY_MS = \"connector_io_tasks_slow_io_latency_ms\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2579
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_IO_TASKS_SLOW_IO_LATENCY_MS, flag = VariableMgr.INVISIBLE) private int connectorIoTasksSlowIoLatency = 50"
+      thrift_propagation: null
+
+  - name: "connector_scan_use_query_mem_ratio"
+    type: double
+    default: 0.3
+    scope: "session"
+    mutable: true
+    description: >
+      Fraction of query memory budget that connector scans can use.
+      Controls memory allocation for external table scans.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 669
+          context: "public static final String CONNECTOR_SCAN_USE_QUERY_MEM_RATIO = \"connector_scan_use_query_mem_ratio\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2585
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SCAN_USE_QUERY_MEM_RATIO) private double connectorScanUseQueryMemRatio = 0.3"
+      thrift_propagation: null
+
+  - name: "connector_max_split_size"
+    type: long
+    default: 67108864
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum split size in bytes for files in object storage or HDFS.
+      Default is 64 MB. Splits larger files into smaller scan ranges.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 999
+          context: "public static final String CONNECTOR_MAX_SPLIT_SIZE = \"connector_max_split_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2945
+          context: "@VarAttr(name = CONNECTOR_MAX_SPLIT_SIZE) private long connectorMaxSplitSize = 64L * 1024L * 1024L"
+      thrift_propagation: null
+
+  - name: "connector_huge_file_size"
+    type: long
+    default: 536870912
+    scope: "session"
+    mutable: true
+    description: >
+      Threshold in bytes above which FE forces file splitting across
+      BEs even for formats that BE can split natively. Default 512 MB.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1006
+          context: "public static final String CONNECTOR_HUGE_FILE_SIZE = \"connector_huge_file_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2948
+          context: "@VarAttr(name = CONNECTOR_HUGE_FILE_SIZE) private long connectorHugeFileSize = 512L * 1024L * 1024L"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Connector sink parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_connector_sink_global_shuffle"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to add a global shuffle between the connector sink fragment
+      and its child fragment. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 566
+          context: "public static final String ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE = \"enable_connector_sink_global_shuffle\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1488
+          context: "@VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE) private boolean enableConnectorSinkGlobalShuffle = true"
+      thrift_propagation: null
+
+  - name: "connector_sink_shuffle_mode"
+    type: String
+    default: "auto"
+    scope: "session"
+    mutable: true
+    description: >
+      Controls the shuffle mode for connector table sinks (Iceberg, Hive,
+      File, etc.). Options: auto, none, global, local.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 582
+          context: "public static final String CONNECTOR_SINK_SHUFFLE_MODE = \"connector_sink_shuffle_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1495
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_MODE) private String connectorSinkShuffleMode = ConnectorSinkShuffleMode.AUTO.modeName()"
+      thrift_propagation: null
+
+  - name: "connector_sink_shuffle_partition_threshold"
+    type: long
+    default: 500
+    scope: "session"
+    mutable: true
+    description: >
+      Partition count threshold for deciding shuffle strategy in connector
+      sinks. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 587
+          context: "public static final String CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD = \"connector_sink_shuffle_partition_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1498
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD, flag = VariableMgr.INVISIBLE) private long connectorSinkShufflePartitionThreshold = 500"
+      thrift_propagation: null
+
+  - name: "connector_sink_shuffle_partition_node_ratio"
+    type: double
+    default: 2.0
+    scope: "session"
+    mutable: true
+    description: >
+      Ratio of partitions to nodes used when deciding shuffle strategy
+      for connector sinks. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 592
+          context: "public static final String CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO = \"connector_sink_shuffle_partition_node_ratio\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1501
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO, flag = VariableMgr.INVISIBLE) private double connectorSinkShufflePartitionNodeRatio = 2.0"
+      thrift_propagation: null
+
+  - name: "enable_connector_sink_spill"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to enable spilling for connector sink operations when memory
+      pressure is high. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 594
+          context: "public static final String ENABLE_CONNECTOR_SINK_SPILL = \"enable_connector_sink_spill\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1504
+          context: "@VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE) private boolean enableConnectorSinkSpill = true"
+      thrift_propagation: null
+
+  - name: "connector_sink_spill_mem_limit_threshold"
+    type: double
+    default: 0.5
+    scope: "session"
+    mutable: true
+    description: >
+      Memory fraction threshold that triggers spilling in connector sinks.
+      Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 595
+          context: "public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = \"connector_sink_spill_mem_limit_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1507
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD, flag = VariableMgr.INVISIBLE) private double connectorSinkSpillMemLimitThreshold = 0.5"
+      thrift_propagation: null
+
+  - name: "connector_sink_sort_scope"
+    type: String
+    default: "file"
+    scope: "session"
+    mutable: true
+    description: >
+      Controls the sort scope for connector sink writes. Options include
+      file-level and partition-level sorting.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 596
+          context: "public static final String CONNECTOR_SINK_SORT_SCOPE = \"connector_sink_sort_scope\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1510
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SINK_SORT_SCOPE) private String connectorSinkSortScope = ConnectorSinkSortScope.FILE.scopeName()"
+      thrift_propagation: null
+
+  - name: "connector_sink_compression_codec"
+    type: String
+    default: "uncompressed"
+    scope: "session"
+    mutable: true
+    description: >
+      Compression codec used when writing data via connector sinks.
+      Supported values depend on the target file format.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 670
+          context: "public static final String CONNECTOR_SINK_COMPRESSION_CODEC = \"connector_sink_compression_codec\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2588
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SINK_COMPRESSION_CODEC) private String connectorSinkCompressionCodec = \"uncompressed\""
+      thrift_propagation: null
+
+  - name: "connector_sink_target_max_file_size"
+    type: long
+    default: 1073741824
+    scope: "session"
+    mutable: true
+    description: >
+      Target maximum file size in bytes for connector sink output files.
+      Default is 1 GB. Files are rolled when approaching this size.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 672
+          context: "public static final String CONNECTOR_SINK_TARGET_MAX_FILE_SIZE = \"connector_sink_target_max_file_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2595
+          context: "@VariableMgr.VarAttr(name = CONNECTOR_SINK_TARGET_MAX_FILE_SIZE) private long connectorSinkTargetMaxFileSize = 1024L * 1024 * 1024"
+      thrift_propagation: null
+
+  - name: "enable_connector_sink_writer_scaling"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to dynamically scale the number of sink writers based
+      on throughput for connector table writes.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1008
+          context: "public static final String ENABLE_CONNECTOR_SINK_WRITER_SCALING = \"enable_connector_sink_writer_scaling\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2951
+          context: "@VarAttr(name = ENABLE_CONNECTOR_SINK_WRITER_SCALING) private boolean enableConnectorSinkWriterScaling = true"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Connector async/incremental scan parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "connector_remote_file_async_queue_size"
+    type: int
+    default: 1000
+    scope: "session"
+    mutable: true
+    description: >
+      Queue size for async remote file listing operations. Invisible
+      session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1018
+          context: "public static final String CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE = \"connector_remote_file_async_queue_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3099
+          context: "@VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE, flag = VariableMgr.INVISIBLE) private int connectorRemoteFileAsyncQueueSize = 1000"
+      thrift_propagation: null
+
+  - name: "connector_remote_file_async_task_size"
+    type: int
+    default: 4
+    scope: "session"
+    mutable: true
+    description: >
+      Number of concurrent async tasks for remote file listing. Invisible
+      session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1019
+          context: "public static final String CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE = \"connector_remote_file_async_task_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3102
+          context: "@VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE, flag = VariableMgr.INVISIBLE) private int connectorRemoteFileAsyncTaskSize = 4"
+      thrift_propagation: null
+
+  - name: "enable_connector_incremental_scan_ranges"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to incrementally deliver scan ranges to BE nodes rather
+      than all at once, reducing planning latency for large tables.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1020
+          context: "public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = \"enable_connector_incremental_scan_ranges\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3105
+          context: "@VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES) private boolean enableConnectorIncrementalScanRanges = true"
+      thrift_propagation: null
+
+  - name: "connector_incremental_scan_ranges_size"
+    type: int
+    default: 500
+    scope: "session"
+    mutable: true
+    description: >
+      Number of scan ranges per incremental batch when delivering scan
+      ranges to BE nodes incrementally.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1021
+          context: "public static final String CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE = \"connector_incremental_scan_ranges_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3111
+          context: "@VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE) private int connectorIncrementalScanRangeSize = 500"
+      thrift_propagation: null
+
+  - name: "enable_connector_async_list_partitions"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to asynchronously list partitions for connector tables
+      during query planning.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1022
+          context: "public static final String ENABLE_CONNECTOR_ASYNC_LIST_PARTITIONS = \"enable_connector_async_list_partitions\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3114
+          context: "@VarAttr(name = ENABLE_CONNECTOR_ASYNC_LIST_PARTITIONS) private boolean enableConnectorAsyncListPartitions = false"
+      thrift_propagation: null
+
+  - name: "enable_connector_deploy_scan_ranges_background"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to deploy scan ranges to BE nodes in background threads
+      to reduce planning latency.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1023
+          context: "public static final String ENABLE_CONNECTOR_DEPLOY_SCAN_RANGES_BACKGROUND"
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3108
+          context: "@VarAttr(name = ENABLE_CONNECTOR_DEPLOY_SCAN_RANGES_BACKGROUND) private boolean enableConnectorDeployScanRangesBackground = true"
+      thrift_propagation: null
+
+  - name: "enable_insert_select_external_auto_refresh"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to automatically refresh external table metadata cache
+      after INSERT INTO ... SELECT from an external table.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1080
+          context: "public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = \"enable_insert_select_external_auto_refresh\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2283
+          context: "@VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH) private boolean enableInsertSelectExternalAutoRefresh = true"
+      thrift_propagation: null
+
+# =============================================================================
+# BE Configs - External storage and connector
+# =============================================================================
+
+be_configs:
+
+  - name: "max_hdfs_scanner_num"
+    type: Int32
+    default: 50
+    scope: "BE"
+    mutable: false
+    description: >
+      Maximum number of HDFS scanner threads per BE node.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 284
+          context: "CONF_Int32(max_hdfs_scanner_num, \"50\")"
+      thrift_propagation: null
+
+  - name: "max_hdfs_file_handle"
+    type: Int32
+    default: 1000
+    scope: "BE"
+    mutable: true
+    description: >
+      Maximum number of cached HDFS file handles per BE node.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1046
+          context: "CONF_mInt32(max_hdfs_file_handle, \"1000\")"
+      thrift_propagation: null
+
+  - name: "pipeline_connector_scan_thread_num_per_cpu"
+    type: double
+    default: 8.0
+    scope: "BE"
+    mutable: true
+    description: >
+      Number of connector scan threads per CPU core for pipeline engine.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 985
+          context: "CONF_mDouble(pipeline_connector_scan_thread_num_per_cpu, \"8\")"
+      thrift_propagation: null
+
+  - name: "connector_io_tasks_per_scan_operator"
+    type: Int32
+    default: 16
+    scope: "BE"
+    mutable: false
+    description: >
+      Default number of I/O tasks per connector scan operator on BE side.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1135
+          context: "CONF_Int32(connector_io_tasks_per_scan_operator, \"16\")"
+      thrift_propagation: null
+
+  - name: "connector_io_tasks_min_size"
+    type: Int32
+    default: 2
+    scope: "BE"
+    mutable: false
+    description: >
+      Minimum number of I/O tasks for connector scan operators.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1136
+          context: "CONF_Int32(connector_io_tasks_min_size, \"2\")"
+      thrift_propagation: null
+
+  - name: "connector_io_tasks_adjust_interval_ms"
+    type: Int32
+    default: 50
+    scope: "BE"
+    mutable: false
+    description: >
+      Interval in milliseconds between I/O task count adjustments for
+      adaptive connector scanning.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1137
+          context: "CONF_Int32(connector_io_tasks_adjust_interval_ms, \"50\")"
+      thrift_propagation: null
+
+  - name: "connector_io_tasks_adjust_step"
+    type: Int32
+    default: 1
+    scope: "BE"
+    mutable: false
+    description: >
+      Step size for adjusting the number of I/O tasks during adaptive
+      connector scanning.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1138
+          context: "CONF_Int32(connector_io_tasks_adjust_step, \"1\")"
+      thrift_propagation: null
+
+  - name: "connector_io_tasks_adjust_smooth"
+    type: Int32
+    default: 4
+    scope: "BE"
+    mutable: false
+    description: >
+      Smoothing factor for I/O task adjustment to avoid oscillation.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1139
+          context: "CONF_Int32(connector_io_tasks_adjust_smooth, \"4\")"
+      thrift_propagation: null
+
+  - name: "connector_io_tasks_slow_io_latency_ms"
+    type: Int32
+    default: 50
+    scope: "BE"
+    mutable: false
+    description: >
+      Latency threshold in ms for classifying I/O as slow on BE side.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1140
+          context: "CONF_Int32(connector_io_tasks_slow_io_latency_ms, \"50\")"
+      thrift_propagation: null
+
+  - name: "connector_scan_use_query_mem_ratio"
+    type: double
+    default: 0.3
+    scope: "BE"
+    mutable: false
+    description: >
+      Fraction of query memory that connector scans can use on BE side.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1142
+          context: "CONF_Double(connector_scan_use_query_mem_ratio, \"0.3\")"
+      thrift_propagation: null
+
+  - name: "connector_sink_mem_high_watermark_ratio"
+    type: double
+    default: 0.3
+    scope: "BE"
+    mutable: true
+    description: >
+      High watermark ratio of memory usage that triggers backpressure
+      on connector sinks.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1728
+          context: "CONF_mDouble(connector_sink_mem_high_watermark_ratio, \"0.3\")"
+      thrift_propagation: null
+
+  - name: "connector_sink_mem_low_watermark_ratio"
+    type: double
+    default: 0.1
+    scope: "BE"
+    mutable: true
+    description: >
+      Low watermark ratio of memory usage that releases backpressure
+      on connector sinks.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1729
+          context: "CONF_mDouble(connector_sink_mem_low_watermark_ratio, \"0.1\")"
+      thrift_propagation: null
+
+  - name: "connector_sink_mem_urgent_space_ratio"
+    type: double
+    default: 0.05
+    scope: "BE"
+    mutable: true
+    description: >
+      Urgent space ratio for connector sink memory management.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1730
+          context: "CONF_mDouble(connector_sink_mem_urgent_space_ratio, \"0.05\")"
+      thrift_propagation: null
+
+  - name: "enable_connector_sink_spill"
+    type: boolean
+    default: true
+    scope: "BE"
+    mutable: true
+    description: >
+      Whether to enable spilling for connector sink operations on BE side.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1732
+          context: "CONF_mBool(enable_connector_sink_spill, \"true\")"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Object storage configs
+  # ---------------------------------------------------------------------------
+
+  - name: "object_storage_access_key_id"
+    type: String
+    default: ""
+    scope: "BE"
+    mutable: false
+    description: >
+      Access key ID for object storage (S3, GCS, etc.) authentication.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1058
+          context: "CONF_String(object_storage_access_key_id, \"\")"
+      thrift_propagation: null
+
+  - name: "object_storage_secret_access_key"
+    type: String
+    default: ""
+    scope: "BE"
+    mutable: false
+    description: >
+      Secret access key for object storage authentication.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1059
+          context: "CONF_String(object_storage_secret_access_key, \"\")"
+      thrift_propagation: null
+
+  - name: "object_storage_endpoint"
+    type: String
+    default: ""
+    scope: "BE"
+    mutable: false
+    description: >
+      Endpoint URL for object storage service.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1060
+          context: "CONF_String(object_storage_endpoint, \"\")"
+      thrift_propagation: null
+
+  - name: "object_storage_bucket"
+    type: String
+    default: ""
+    scope: "BE"
+    mutable: false
+    description: >
+      Default bucket name for object storage operations.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1061
+          context: "CONF_String(object_storage_bucket, \"\")"
+      thrift_propagation: null
+
+  - name: "object_storage_region"
+    type: String
+    default: ""
+    scope: "BE"
+    mutable: false
+    description: >
+      Region for object storage service.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1063
+          context: "CONF_String(object_storage_region, \"\")"
+      thrift_propagation: null
+
+  - name: "object_storage_max_connection"
+    type: Int64
+    default: 102400
+    scope: "BE"
+    mutable: false
+    description: >
+      Maximum number of connections to object storage service.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1064
+          context: "CONF_Int64(object_storage_max_connection, \"102400\")"
+      thrift_propagation: null
+
+  - name: "object_storage_endpoint_use_https"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: false
+    description: >
+      Whether to use HTTPS for object storage endpoint connections.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1067
+          context: "CONF_Bool(object_storage_endpoint_use_https, \"false\")"
+      thrift_propagation: null
+
+  - name: "object_storage_endpoint_path_style_access"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: false
+    description: >
+      Whether to use path-style access for object storage (vs virtual-hosted).
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1070
+          context: "CONF_Bool(object_storage_endpoint_path_style_access, \"false\")"
+      thrift_propagation: null
+
+  - name: "object_storage_connect_timeout_ms"
+    type: Int64
+    default: -1
+    scope: "BE"
+    mutable: false
+    description: >
+      Connection timeout in milliseconds for object storage. -1 uses SDK default.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1074
+          context: "CONF_Int64(object_storage_connect_timeout_ms, \"-1\")"
+      thrift_propagation: null
+
+  - name: "object_storage_request_timeout_ms"
+    type: Int64
+    default: -1
+    scope: "BE"
+    mutable: true
+    description: >
+      Request timeout in milliseconds for object storage. -1 uses SDK default.
+      Aliased as starlet_fslib_s3client_request_timeout_ms.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1082
+          context: "CONF_mInt64(object_storage_request_timeout_ms, \"-1\")"
+      thrift_propagation: null
+
+  - name: "object_storage_rename_file_request_timeout_ms"
+    type: Int64
+    default: 30000
+    scope: "BE"
+    mutable: false
+    description: >
+      Timeout in milliseconds for object storage rename file requests.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1085
+          context: "CONF_Int64(object_storage_rename_file_request_timeout_ms, \"30000\")"
+      thrift_propagation: null
+
+  - name: "object_storage_max_retries"
+    type: Int64
+    default: 10
+    scope: "BE"
+    mutable: false
+    description: >
+      Maximum number of retries for failed object storage requests.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1089
+          context: "CONF_Int64(object_storage_max_retries, \"10\")"
+      thrift_propagation: null
+
+  - name: "object_storage_retry_scale_factor"
+    type: Int64
+    default: 25
+    scope: "BE"
+    mutable: false
+    description: >
+      Scale factor for exponential backoff between object storage retries.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1090
+          context: "CONF_Int64(object_storage_retry_scale_factor, \"25\")"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # S3 and HDFS configs
+  # ---------------------------------------------------------------------------
+
+  - name: "s3_compatible_fs_list"
+    type: Strings
+    default: "s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://"
+    scope: "BE"
+    mutable: false
+    description: >
+      Comma-separated list of S3-compatible filesystem URI schemes.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1093
+          context: "CONF_Strings(s3_compatible_fs_list, ...)"
+      thrift_propagation: null
+
+  - name: "s3_use_list_objects_v1"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: true
+    description: >
+      Whether to use ListObjectsV1 API instead of V2 for S3-compatible
+      storage. Needed for some S3-compatible implementations.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1094
+          context: "CONF_mBool(s3_use_list_objects_v1, \"false\")"
+      thrift_propagation: null
+
+  - name: "hdfs_client_enable_hedged_read"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: false
+    description: >
+      Whether to enable hedged reads for HDFS client to reduce tail latency.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1145
+          context: "CONF_Bool(hdfs_client_enable_hedged_read, \"false\")"
+      thrift_propagation: null
+
+  - name: "hdfs_client_hedged_read_threadpool_size"
+    type: Int32
+    default: 128
+    scope: "BE"
+    mutable: false
+    description: >
+      Thread pool size for HDFS hedged reads.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1147
+          context: "CONF_Int32(hdfs_client_hedged_read_threadpool_size, \"128\")"
+      thrift_propagation: null
+
+  - name: "hdfs_client_hedged_read_threshold_millis"
+    type: Int32
+    default: 2500
+    scope: "BE"
+    mutable: false
+    description: >
+      Time threshold in milliseconds before a hedged read is initiated.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1149
+          context: "CONF_Int32(hdfs_client_hedged_read_threshold_millis, \"2500\")"
+      thrift_propagation: null
+
+  - name: "hdfs_client_max_cache_size"
+    type: Int32
+    default: 64
+    scope: "BE"
+    mutable: false
+    description: >
+      Maximum number of cached HDFS client instances.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1150
+          context: "CONF_Int32(hdfs_client_max_cache_size, \"64\")"
+      thrift_propagation: null
+
+  - name: "hdfs_client_io_read_retry"
+    type: Int32
+    default: 0
+    scope: "BE"
+    mutable: false
+    description: >
+      Number of retries for HDFS read I/O errors. 0 means no retry.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1151
+          context: "CONF_Int32(hdfs_client_io_read_retry, \"0\")"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # JDBC configs
+  # ---------------------------------------------------------------------------
+
+  - name: "jdbc_connection_pool_size"
+    type: Int16
+    default: 8
+    scope: "BE"
+    mutable: false
+    description: >
+      Size of the JDBC connection pool per BE node.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1340
+          context: "CONF_Int16(jdbc_connection_pool_size, \"8\")"
+      thrift_propagation: null
+
+  - name: "jdbc_minimum_idle_connections"
+    type: Int16
+    default: 1
+    scope: "BE"
+    mutable: false
+    description: >
+      Minimum number of idle connections maintained in JDBC pool.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1344
+          context: "CONF_Int16(jdbc_minimum_idle_connections, \"1\")"
+      thrift_propagation: null
+
+  - name: "jdbc_connection_idle_timeout_ms"
+    type: Int32
+    default: 600000
+    scope: "BE"
+    mutable: false
+    description: >
+      Idle timeout in milliseconds before a JDBC connection is evicted
+      from the pool. Default is 10 minutes.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1348
+          context: "CONF_Int32(jdbc_connection_idle_timeout_ms, \"600000\")"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Cloud-native / shared-data configs
+  # ---------------------------------------------------------------------------
+
+  - name: "cloud_native_pk_index_rebuild_files_threshold"
+    type: Int32
+    default: 50
+    scope: "BE"
+    mutable: true
+    description: >
+      File count threshold for triggering primary key index rebuild
+      in cloud-native (shared-data) mode.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1313
+          context: "CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, \"50\")"
+      thrift_propagation: null

--- a/param-docs/09_network_timeout.yml
+++ b/param-docs/09_network_timeout.yml
@@ -1,0 +1,464 @@
+# =============================================================================
+# StarRocks Network and Timeout Parameters
+# Source: fe/.../qe/SessionVariable.java, be/src/common/config.h
+# =============================================================================
+
+session_variables:
+
+  - name: "query_timeout"
+    type: int
+    default: 300
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum execution time in seconds for a query before it is
+      cancelled. Default is 5 minutes.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 157
+          context: "public static final String QUERY_TIMEOUT = \"query_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1231
+          context: "@VariableMgr.VarAttr(name = QUERY_TIMEOUT) private int queryTimeoutS = 300"
+      thrift_propagation: null
+
+  - name: "metadata_collect_query_timeout"
+    type: int
+    default: 60
+    scope: "session"
+    mutable: true
+    description: >
+      Timeout in seconds for metadata collection queries such as
+      ANALYZE and statistics gathering. Default is 1 minute.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 159
+          context: "public static final String METADATA_COLLECT_QUERY_TIMEOUT = \"metadata_collect_query_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1235
+          context: "@VariableMgr.VarAttr(name = METADATA_COLLECT_QUERY_TIMEOUT) private int metadataCollectQueryTimeoutS = 60"
+      thrift_propagation: null
+
+  - name: "query_delivery_timeout"
+    type: int
+    default: 300
+    scope: "session"
+    mutable: true
+    description: >
+      Timeout in seconds for delivering query fragments from FE to BE
+      nodes. Default is 5 minutes.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 168
+          context: "public static final String QUERY_DELIVERY_TIMEOUT = \"query_delivery_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1245
+          context: "@VariableMgr.VarAttr(name = QUERY_DELIVERY_TIMEOUT) private int queryDeliveryTimeoutS = 300"
+      thrift_propagation: null
+
+  - name: "insert_timeout"
+    type: int
+    default: 14400
+    scope: "session"
+    mutable: true
+    description: >
+      Timeout in seconds for INSERT operations. Default is 4 hours.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 229
+          context: "public static final String INSERT_TIMEOUT = \"insert_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1556
+          context: "@VariableMgr.VarAttr(name = INSERT_TIMEOUT) private int insertTimeoutS = 14400"
+      thrift_propagation: null
+
+  - name: "interactive_timeout"
+    type: int
+    default: 3600
+    scope: "session"
+    mutable: true
+    description: >
+      Number of seconds the server waits for activity on an interactive
+      connection before closing it. Default is 1 hour.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 208
+          context: "public static final String INTERACTIVE_TIMEOUT = \"interactive_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1357
+          context: "@VariableMgr.VarAttr(name = INTERACTIVE_TIMEOUT) private int interactiveTimeout = 3600"
+      thrift_propagation: null
+
+  - name: "wait_timeout"
+    type: int
+    default: 28800
+    scope: "session"
+    mutable: true
+    description: >
+      Number of seconds the server waits for activity on a non-interactive
+      connection before closing it. Default is 8 hours.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 209
+          context: "public static final String WAIT_TIMEOUT = \"wait_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1361
+          context: "@VariableMgr.VarAttr(name = WAIT_TIMEOUT) private int waitTimeout = 28800"
+      thrift_propagation: null
+
+  - name: "net_write_timeout"
+    type: int
+    default: 60
+    scope: "session"
+    mutable: true
+    description: >
+      Number of seconds to wait for a block to be written to a connection
+      before aborting the write.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 212
+          context: "public static final String NET_WRITE_TIMEOUT = \"net_write_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1365
+          context: "@VariableMgr.VarAttr(name = NET_WRITE_TIMEOUT) private int netWriteTimeout = 60"
+      thrift_propagation: null
+
+  - name: "net_read_timeout"
+    type: int
+    default: 60
+    scope: "session"
+    mutable: true
+    description: >
+      Number of seconds to wait for more data from a connection before
+      aborting the read.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 213
+          context: "public static final String NET_READ_TIMEOUT = \"net_read_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1369
+          context: "@VariableMgr.VarAttr(name = NET_READ_TIMEOUT) private int netReadTimeout = 60"
+      thrift_propagation: null
+
+  - name: "net_buffer_length"
+    type: int
+    default: 16384
+    scope: "session"
+    mutable: false
+    description: >
+      Buffer length for network communication. Read-only variable
+      for MySQL protocol compatibility. Default is 16 KB.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 217
+          context: "public static final String NET_BUFFER_LENGTH = \"net_buffer_length\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1386
+          context: "@VariableMgr.VarAttr(name = NET_BUFFER_LENGTH, flag = VariableMgr.READ_ONLY) private int netBufferLength = 16384"
+      thrift_propagation: null
+
+  - name: "max_allowed_packet"
+    type: int
+    default: 33554432
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum size of a single network packet in bytes. Default is 32 MB.
+      Used for MySQL protocol compatibility.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 205
+          context: "public static final String MAX_ALLOWED_PACKET = \"max_allowed_packet\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1347
+          context: "@VariableMgr.VarAttr(name = MAX_ALLOWED_PACKET) private int maxAllowedPacket = 33554432"
+      thrift_propagation: null
+
+  - name: "tx_visible_wait_timeout"
+    type: long
+    default: 10
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum time in seconds to wait for a transaction to become visible
+      after commit. Used for read-after-write consistency.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 378
+          context: "public static final String TRANSACTION_VISIBLE_WAIT_TIMEOUT = \"tx_visible_wait_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1732
+          context: "@VariableMgr.VarAttr(name = TRANSACTION_VISIBLE_WAIT_TIMEOUT) private long transactionVisibleWaitTimeout = 10"
+      thrift_propagation: null
+
+  - name: "thrift_plan_protocol"
+    type: String
+    default: "binary"
+    scope: "session"
+    mutable: true
+    description: >
+      Thrift protocol used for serializing query plans sent from FE to BE.
+      Options: binary, compact.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 934
+          context: "public static final String THRIFT_PLAN_PROTOCOL = \"thrift_plan_protocol\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2079
+          context: "@VarAttr(name = THRIFT_PLAN_PROTOCOL) private String thriftPlanProtocol = \"binary\""
+      thrift_propagation: null
+
+# =============================================================================
+# BE Configs - Network and Timeout
+# =============================================================================
+
+be_configs:
+
+  - name: "thrift_port"
+    type: Int32
+    default: 0
+    scope: "BE"
+    mutable: false
+    description: >
+      Port for Thrift RPC service on BE. 0 means auto-assigned. Used
+      for FE-to-BE and BE-to-BE communication.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 44
+          context: "CONF_Int32(thrift_port, \"0\")"
+      thrift_propagation: null
+
+  - name: "brpc_port"
+    type: Int32
+    default: 8060
+    scope: "BE"
+    mutable: false
+    description: >
+      Port for bRPC service on BE. Used for high-performance inter-node
+      data exchange during query execution.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 47
+          context: "CONF_Int32(brpc_port, \"8060\")"
+      thrift_propagation: null
+
+  - name: "brpc_num_threads"
+    type: Int32
+    default: -1
+    scope: "BE"
+    mutable: false
+    description: >
+      Number of bRPC worker threads. -1 means auto (typically number
+      of CPU cores).
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 50
+          context: "CONF_Int32(brpc_num_threads, \"-1\")"
+      thrift_propagation: null
+
+  - name: "brpc_max_body_size"
+    type: Int64
+    default: 2147483648
+    scope: "BE"
+    mutable: false
+    description: >
+      Maximum body size in bytes for a single bRPC message. Default is 2 GB.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 848
+          context: "CONF_Int64(brpc_max_body_size, \"2147483648\")"
+      thrift_propagation: null
+
+  - name: "brpc_socket_max_unwritten_bytes"
+    type: Int64
+    default: 1073741824
+    scope: "BE"
+    mutable: false
+    description: >
+      Maximum number of unwritten bytes buffered in a bRPC socket before
+      applying backpressure. Default is 1 GB.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 850
+          context: "CONF_Int64(brpc_socket_max_unwritten_bytes, \"1073741824\")"
+      thrift_propagation: null
+
+  - name: "thrift_connect_timeout_seconds"
+    type: Int32
+    default: 3
+    scope: "BE"
+    mutable: false
+    description: >
+      Connection timeout in seconds for outgoing Thrift RPC connections.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 276
+          context: "CONF_Int32(thrift_connect_timeout_seconds, \"3\")"
+      thrift_propagation: null
+
+  - name: "thrift_rpc_timeout_ms"
+    type: Int32
+    default: 5000
+    scope: "BE"
+    mutable: true
+    description: >
+      Timeout in milliseconds for Thrift RPC calls. Default is 5 seconds.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 760
+          context: "CONF_mInt32(thrift_rpc_timeout_ms, \"5000\")"
+      thrift_propagation: null
+
+  - name: "rpc_connect_timeout_ms"
+    type: Int64
+    default: 30000
+    scope: "BE"
+    mutable: false
+    description: >
+      Connection timeout in milliseconds for general RPC connections.
+      Default is 30 seconds.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1196
+          context: "CONF_Int64(rpc_connect_timeout_ms, \"30000\")"
+      thrift_propagation: null
+
+  - name: "heartbeat_service_port"
+    type: Int32
+    default: 9050
+    scope: "BE"
+    mutable: false
+    description: >
+      Port for the heartbeat service on BE. Used by FE to monitor
+      BE liveness.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 115
+          context: "CONF_Int32(heartbeat_service_port, \"9050\")"
+      thrift_propagation: null
+
+  - name: "be_http_port"
+    type: Int32
+    default: 8040
+    scope: "BE"
+    mutable: false
+    description: >
+      Port for the HTTP service on BE. Used for web UI, metrics,
+      and REST API endpoints. Alias: webserver_port.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 506
+          context: "CONF_Int32(be_http_port, \"8040\")"
+      thrift_propagation: null
+
+  - name: "be_http_num_workers"
+    type: Int32
+    default: 48
+    scope: "BE"
+    mutable: false
+    description: >
+      Number of HTTP server worker threads on BE.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 509
+          context: "CONF_Int32(be_http_num_workers, \"48\")"
+      thrift_propagation: null
+
+  - name: "object_storage_connect_timeout_ms"
+    type: Int64
+    default: -1
+    scope: "BE"
+    mutable: false
+    description: >
+      Connection timeout in milliseconds for object storage. -1 uses
+      the SDK default.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1074
+          context: "CONF_Int64(object_storage_connect_timeout_ms, \"-1\")"
+      thrift_propagation: null
+
+  - name: "object_storage_request_timeout_ms"
+    type: Int64
+    default: -1
+    scope: "BE"
+    mutable: true
+    description: >
+      Request timeout in milliseconds for object storage operations.
+      -1 uses SDK default. Also aliased as
+      starlet_fslib_s3client_request_timeout_ms.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1082
+          context: "CONF_mInt64(object_storage_request_timeout_ms, \"-1\")"
+      thrift_propagation: null
+
+  - name: "tablet_writer_open_rpc_timeout_sec"
+    type: Int32
+    default: 300
+    scope: "BE"
+    mutable: true
+    description: >
+      Timeout in seconds for the RPC to open a tablet writer during
+      data loading. Actual timeout is min(this, load_timeout_sec / 2).
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 591
+          context: "CONF_mInt32(tablet_writer_open_rpc_timeout_sec, \"300\")"
+      thrift_propagation: null
+
+  - name: "txn_commit_rpc_timeout_ms"
+    type: Int32
+    default: 60000
+    scope: "BE"
+    mutable: true
+    description: >
+      Timeout in milliseconds for the transaction commit RPC call.
+      Default is 60 seconds.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 771
+          context: "CONF_mInt32(txn_commit_rpc_timeout_ms, \"60000\")"
+      thrift_propagation: null
+
+  - name: "jdbc_connection_idle_timeout_ms"
+    type: Int32
+    default: 600000
+    scope: "BE"
+    mutable: false
+    description: >
+      Idle timeout in milliseconds before a JDBC connection is evicted
+      from the connection pool. Default is 10 minutes.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1348
+          context: "CONF_Int32(jdbc_connection_idle_timeout_ms, \"600000\")"
+      thrift_propagation: null

--- a/param-docs/10_statistics_cost_estimation.yml
+++ b/param-docs/10_statistics_cost_estimation.yml
@@ -1,0 +1,363 @@
+# =============================================================================
+# StarRocks Statistics and Cost Estimation Parameters
+# Source: fe/.../qe/SessionVariable.java
+# =============================================================================
+
+session_variables:
+
+  # ---------------------------------------------------------------------------
+  # Statistics collection parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "statistic_collect_parallel"
+    type: int
+    default: 1
+    scope: "session"
+    mutable: true
+    description: >
+      Parallelism level for statistics collection tasks. Controls how
+      many columns are analyzed concurrently. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 613
+          context: "public static final String STATISTIC_COLLECT_PARALLEL = \"statistic_collect_parallel\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1948
+          context: "@VarAttr(name = STATISTIC_COLLECT_PARALLEL, flag = VariableMgr.INVISIBLE) private int statisticCollectParallelism = 1"
+      thrift_propagation: null
+
+  - name: "statistic_meta_collect_parallel"
+    type: int
+    default: 10
+    scope: "session"
+    mutable: true
+    description: >
+      Parallelism level for statistics metadata collection. Controls
+      concurrent metadata fetch operations. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 615
+          context: "public static final String STATISTIC_META_COLLECT_PARALLEL = \"statistic_meta_collect_parallel\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1951
+          context: "@VarAttr(name = STATISTIC_META_COLLECT_PARALLEL, flag = VariableMgr.INVISIBLE) private int statisticMetaCollectParallelism = 10"
+      thrift_propagation: null
+
+  - name: "enable_analyze_phase_prune_columns"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to prune columns during the analyze phase to reduce the
+      amount of statistics collected. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 617
+          context: "public static final String ENABLE_ANALYZE_PHASE_PRUNE_COLUMNS = \"enable_analyze_phase_prune_columns\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1954
+          context: "@VarAttr(name = ENABLE_ANALYZE_PHASE_PRUNE_COLUMNS, flag = VariableMgr.INVISIBLE) private boolean enableAnalyzePhasePruneColumns = false"
+      thrift_propagation: null
+
+  - name: "enable_query_trigger_analyze"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether queries can trigger automatic statistics collection when
+      statistics are missing or stale.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 547
+          context: "public static final String ENABLE_QUERY_TRIGGER_ANALYZE = \"enable_query_trigger_analyze\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3043
+          context: "@VarAttr(name = ENABLE_QUERY_TRIGGER_ANALYZE) private boolean enableQueryTriggerAnalyze = true"
+      thrift_propagation: null
+
+  - name: "enable_collect_table_level_scan_stats"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to collect table-level scan statistics during query
+      execution for use in cost estimation.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 929
+          context: "public static final String ENABLE_COLLECT_TABLE_LEVEL_SCAN_STATS = \"enable_collect_table_level_scan_stats\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2907
+          context: "@VarAttr(name = ENABLE_COLLECT_TABLE_LEVEL_SCAN_STATS) private boolean enableCollectTableLevelScanStats = true"
+      thrift_propagation: null
+
+  - name: "enable_labeled_column_statistic_output"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to output column statistics with labels in SHOW STATS
+      results for better readability.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1090
+          context: "public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = \"enable_labeled_column_statistic_output\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2300
+          context: "@VarAttr(name = ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT) private boolean enableLabeledColumnStatisticOutput = false"
+      thrift_propagation: null
+
+  - name: "disable_table_stats_from_metadata_for_single_table"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to disable using table statistics from metadata for single
+      table queries, forcing use of collected statistics instead.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 544
+          context: "public static final String DISABLE_TABLE_STATS_FROM_METADATA_FOR_SINGLE_TABLE"
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3040
+          context: "@VarAttr(name = DISABLE_TABLE_STATS_FROM_METADATA_FOR_SINGLE_TABLE) private boolean disableTableStatsFromMetadataForSingleTable = true"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # External table statistics parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "hive_partition_stats_sample_size"
+    type: int
+    default: 3000
+    scope: "session"
+    mutable: true
+    description: >
+      Number of partitions to sample when estimating partition-level
+      statistics for Hive tables. In most cases, partition statistics
+      from Hive Metastore are empty.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 564
+          context: "public static final String HIVE_PARTITION_STATS_SAMPLE_SIZE = \"hive_partition_stats_sample_size\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1919
+          context: "@VariableMgr.VarAttr(name = HIVE_PARTITION_STATS_SAMPLE_SIZE) private int hivePartitionStatsSampleSize = 3000"
+      thrift_propagation: null
+
+  - name: "enable_hive_column_stats"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use column statistics from Hive Metastore for
+      cost-based query optimization on Hive external tables.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 553
+          context: "public static final String ENABLE_HIVE_COLUMN_STATS = \"enable_hive_column_stats\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1910
+          context: "@VariableMgr.VarAttr(name = ENABLE_HIVE_COLUMN_STATS) private boolean enableHiveColumnStats = true"
+      thrift_propagation: null
+
+  - name: "enable_read_iceberg_puffin_ndv"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to read NDV (number of distinct values) statistics from
+      Iceberg Puffin files for cost-based optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 537
+          context: "public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = \"enable_read_iceberg_puffin_ndv\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3028
+          context: "@VarAttr(name = ENABLE_READ_ICEBERG_PUFFIN_NDV) private boolean enableReadIcebergPuffinNdv = true"
+      thrift_propagation: null
+
+  - name: "enable_iceberg_column_statistics"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use Iceberg column-level statistics for cost-based
+      query optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 539
+          context: "public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = \"enable_iceberg_column_statistics\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3031
+          context: "@VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS) private boolean enableIcebergColumnStatistics = false"
+      thrift_propagation: null
+
+  - name: "enable_delta_lake_column_statistics"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use Delta Lake column-level statistics for cost-based
+      query optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 542
+          context: "public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = \"enable_delta_lake_column_statistics\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3037
+          context: "@VarAttr(name = ENABLE_DELTA_LAKE_COLUMN_STATISTICS) private boolean enableDeltaLakeColumnStatistics = false"
+      thrift_propagation: null
+
+  - name: "enable_paimon_column_statistics"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use Paimon column-level statistics for cost-based
+      query optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 549
+          context: "public static final String ENABLE_PAIMON_COLUMN_STATISTICS = \"enable_paimon_column_statistics\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3046
+          context: "@VarAttr(name = ENABLE_PAIMON_COLUMN_STATISTICS) private boolean enablePaimonColumnStatistics = false"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Low cardinality optimization parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "cbo_enable_low_cardinality_optimize"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to enable low-cardinality optimization in the cost-based
+      optimizer. Uses dictionary encoding for string columns with few
+      distinct values to reduce memory and improve performance.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 417
+          context: "public static final String CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE = \"cbo_enable_low_cardinality_optimize\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1763
+          context: "@VariableMgr.VarAttr(name = CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE) private boolean enableLowCardinalityOptimize = true"
+      thrift_propagation: null
+
+  - name: "low_cardinality_optimize_v2"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use version 2 of the low-cardinality optimization,
+      which provides improved dictionary encoding support.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 419
+          context: "public static final String LOW_CARDINALITY_OPTIMIZE_V2 = \"low_cardinality_optimize_v2\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1772
+          context: "@VariableMgr.VarAttr(name = LOW_CARDINALITY_OPTIMIZE_V2) private boolean useLowCardinalityOptimizeV2 = true"
+      thrift_propagation: null
+
+  - name: "low_cardinality_optimize_on_lake"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to apply low-cardinality optimization for queries on
+      lake (external) tables. Disabled by default due to different
+      data characteristics.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 420
+          context: "public static final String LOW_CARDINALITY_OPTIMIZE_ON_LAKE = \"low_cardinality_optimize_on_lake\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1775
+          context: "@VariableMgr.VarAttr(name = LOW_CARDINALITY_OPTIMIZE_ON_LAKE) private boolean useLowCardinalityOptimizeOnLake = false"
+      thrift_propagation: null
+
+  - name: "array_low_cardinality_optimize"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to apply low-cardinality optimization for ARRAY type
+      columns containing low-cardinality string elements.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 421
+          context: "public static final String ARRAY_LOW_CARDINALITY_OPTIMIZE = \"array_low_cardinality_optimize\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1778
+          context: "@VarAttr(name = ARRAY_LOW_CARDINALITY_OPTIMIZE) private boolean enableArrayLowCardinalityOptimize = true"
+      thrift_propagation: null
+
+  - name: "struct_low_cardinality_optimize"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to apply low-cardinality optimization for STRUCT type
+      columns containing low-cardinality string fields.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 422
+          context: "public static final String STRUCT_LOW_CARDINALITY_OPTIMIZE = \"struct_low_cardinality_optimize\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1781
+          context: "@VarAttr(name = STRUCT_LOW_CARDINALITY_OPTIMIZE) private boolean enableStructLowCardinalityOptimize = true"
+      thrift_propagation: null
+
+  - name: "enable_low_cardinality_optimize_for_union_all"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to apply low-cardinality optimization across UNION ALL
+      branches, propagating dictionary encoding through union operators.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 423
+          context: "public static final String ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_UNION_ALL"
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1769
+          context: "@VariableMgr.VarAttr(name = ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_UNION_ALL) private boolean enableLowCardinalityOptimizeForUnionAll = true"
+      thrift_propagation: null

--- a/param-docs/11_security_authentication.yml
+++ b/param-docs/11_security_authentication.yml
@@ -1,0 +1,166 @@
+# =============================================================================
+# StarRocks Security and Authentication Parameters
+# Source: fe/.../qe/SessionVariable.java, be/src/common/config.h
+# =============================================================================
+
+session_variables:
+
+  - name: "sql_mode"
+    type: long
+    default: 32
+    scope: "session"
+    mutable: true
+    description: >
+      SQL mode bitmask controlling SQL behavior (e.g., strict mode,
+      ANSI quotes). The default value (32) corresponds to
+      ONLY_FULL_GROUP_BY. Stored internally as sql_mode_v2 for
+      backwards compatibility after default value change.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 176
+          context: "public static final String SQL_MODE = \"sql_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 183
+          context: "public static final String SQL_MODE_STORAGE_NAME = \"sql_mode_v2\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1264
+          context: "@VariableMgr.VarAttr(name = SQL_MODE_STORAGE_NAME, alias = SQL_MODE, show = SQL_MODE) private long sqlMode = 32L"
+      thrift_propagation: null
+
+  - name: "sql_safe_updates"
+    type: int
+    default: 0
+    scope: "session"
+    mutable: true
+    description: >
+      When enabled (non-zero), prevents UPDATE and DELETE statements that
+      do not use a key column in the WHERE clause, preventing accidental
+      bulk modifications.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 216
+          context: "public static final String SQL_SAFE_UPDATES = \"sql_safe_updates\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1382
+          context: "@VariableMgr.VarAttr(name = SQL_SAFE_UPDATES) private int sqlSafeUpdates = 0"
+      thrift_propagation: null
+
+  - name: "default_authentication_plugin"
+    type: String
+    default: "mysql_native_password"
+    scope: "session"
+    mutable: true
+    description: >
+      The default authentication plugin used for user authentication.
+      Controls the password hashing method for new user accounts.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 194
+          context: "public static final String DEFAULT_AUTHENTICATION_PLUGIN = \"default_authentication_plugin\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1315
+          context: "@VariableMgr.VarAttr(name = DEFAULT_AUTHENTICATION_PLUGIN) private String defaultAuthenticationPlugin = \"mysql_native_password\""
+      thrift_propagation: null
+
+  - name: "authentication_policy"
+    type: String
+    default: "*,,"
+    scope: "session"
+    mutable: true
+    description: >
+      Authentication policy controlling which authentication methods
+      are allowed. Comma-separated list of allowed methods, with
+      wildcards supported.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 195
+          context: "public static final String AUTHENTICATION_POLICY = \"authentication_policy\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1317
+          context: "@VariableMgr.VarAttr(name = AUTHENTICATION_POLICY) private String authenticationPolicy = \"*,,\""
+      thrift_propagation: null
+
+# =============================================================================
+# BE Configs - Security and SSL
+# =============================================================================
+
+be_configs:
+
+  - name: "enable_https"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: false
+    description: >
+      Whether to enable HTTPS for the BE HTTP service. When enabled,
+      ssl_certificate_path and ssl_private_key_path must be configured.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 52
+          context: "CONF_Bool(enable_https, \"false\")"
+      thrift_propagation: null
+
+  - name: "ssl_certificate_path"
+    type: String
+    default: ""
+    scope: "BE"
+    mutable: false
+    description: >
+      File path to the SSL certificate (PEM format) used when HTTPS
+      is enabled for the BE HTTP service.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 54
+          context: "CONF_String(ssl_certificate_path, \"\")"
+      thrift_propagation: null
+
+  - name: "ssl_private_key_path"
+    type: String
+    default: ""
+    scope: "BE"
+    mutable: false
+    description: >
+      File path to the SSL private key (PEM format) used when HTTPS
+      is enabled for the BE HTTP service.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 56
+          context: "CONF_String(ssl_private_key_path, \"\")"
+      thrift_propagation: null
+
+  - name: "enable_token_check"
+    type: boolean
+    default: true
+    scope: "BE"
+    mutable: true
+    description: >
+      Whether to enable token-based authentication for internal RPC
+      calls between FE and BE nodes. Should be true in production.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 667
+          context: "CONF_mBool(enable_token_check, \"true\")"
+      thrift_propagation: null
+
+  - name: "object_storage_endpoint_use_https"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: false
+    description: >
+      Whether to use HTTPS for object storage endpoint connections
+      (S3, GCS, etc.).
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1067
+          context: "CONF_Bool(object_storage_endpoint_use_https, \"false\")"
+      thrift_propagation: null

--- a/param-docs/12_logging_debugging.yml
+++ b/param-docs/12_logging_debugging.yml
@@ -1,0 +1,586 @@
+# =============================================================================
+# StarRocks Logging and Debugging Parameters
+# Source: fe/.../qe/SessionVariable.java, be/src/common/config.h
+# =============================================================================
+
+session_variables:
+
+  # ---------------------------------------------------------------------------
+  # Query profiling parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_profile"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to generate a query execution profile. When enabled,
+      detailed execution metrics are collected and available via
+      SHOW PROFILE. Alias: is_report_success.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 172
+          context: "public static final String ENABLE_PROFILE = \"enable_profile\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1249
+          context: "@VariableMgr.VarAttr(name = ENABLE_PROFILE, alias = IS_REPORT_SUCCESS) private boolean enableProfile = false"
+      thrift_propagation: null
+
+  - name: "enable_metadata_profile"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to include metadata operation timing in the query profile.
+      Shows time spent on catalog, partition, and file listing operations.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 160
+          context: "public static final String ENABLE_METADATA_PROFILE = \"enable_metadata_profile\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1256
+          context: "@VariableMgr.VarAttr(name = ENABLE_METADATA_PROFILE) private boolean enableMetadataProfile = false"
+      thrift_propagation: null
+
+  - name: "enable_load_profile"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to generate profiles for data loading operations
+      (INSERT, BROKER LOAD, etc.).
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 174
+          context: "public static final String ENABLE_LOAD_PROFILE = \"enable_load_profile\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1260
+          context: "@VariableMgr.VarAttr(name = ENABLE_LOAD_PROFILE) private boolean enableLoadProfile = false"
+      thrift_propagation: null
+
+  - name: "profile_timeout"
+    type: int
+    default: 10
+    scope: "session"
+    mutable: true
+    description: >
+      Timeout in seconds for profile report collection from BE nodes.
+      Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 340
+          context: "public static final String PROFILE_TIMEOUT = \"profile_timeout\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1524
+          context: "@VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE) private int profileTimeout = 10"
+      thrift_propagation: null
+
+  - name: "runtime_profile_report_interval"
+    type: int
+    default: 10
+    scope: "session"
+    mutable: true
+    description: >
+      Interval in seconds between runtime profile reports from BE
+      to FE during query execution.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 341
+          context: "public static final String RUNTIME_PROFILE_REPORT_INTERVAL = \"runtime_profile_report_interval\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1527
+          context: "@VariableMgr.VarAttr(name = RUNTIME_PROFILE_REPORT_INTERVAL) private int runtimeProfileReportInterval = 10"
+      thrift_propagation: null
+
+  - name: "pipeline_profile_level"
+    type: int
+    default: 1
+    scope: "session"
+    mutable: true
+    description: >
+      Detail level for pipeline engine profiles. 0 = minimal,
+      1 = standard, 2 = verbose with per-operator metrics.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 342
+          context: "public static final String PIPELINE_PROFILE_LEVEL = \"pipeline_profile_level\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1530
+          context: "@VariableMgr.VarAttr(name = PIPELINE_PROFILE_LEVEL) private int pipelineProfileLevel = 1"
+      thrift_propagation: null
+
+  - name: "enable_async_profile"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to collect and report profiles asynchronously to avoid
+      impacting query latency. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 343
+          context: "public static final String ENABLE_ASYNC_PROFILE = \"enable_async_profile\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1533
+          context: "@VariableMgr.VarAttr(name = ENABLE_ASYNC_PROFILE, flag = VariableMgr.INVISIBLE) private boolean enableAsyncProfile = true"
+      thrift_propagation: null
+
+  - name: "big_query_profile_threshold"
+    type: String
+    default: "30s"
+    scope: "session"
+    mutable: true
+    description: >
+      Duration threshold for automatically enabling profile collection
+      on long-running queries. Queries exceeding this threshold will
+      have their profiles captured.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 828
+          context: "public static final String BIG_QUERY_PROFILE_THRESHOLD = \"big_query_profile_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1536
+          context: "@VariableMgr.VarAttr(name = BIG_QUERY_PROFILE_THRESHOLD) private String bigQueryProfileThreshold = \"30s\""
+      thrift_propagation: null
+
+  - name: "profile_format_version"
+    type: int
+    default: 1
+    scope: "session"
+    mutable: true
+    description: >
+      Version of the profile output format. Different versions may
+      include different metrics and layout.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 345
+          context: "public static final String PROFILE_FORMAT_VERSION = \"profile_format_version\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1540
+          context: "@VariableMgr.VarAttr(name = PROFILE_FORMAT_VERSION) private int profileFormatVersion = 1"
+      thrift_propagation: null
+
+  - name: "enable_show_predicate_tree_in_profile"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to include the predicate tree structure in query profiles
+      for debugging predicate pushdown. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 907
+          context: "public static final String ENABLE_SHOW_PREDICATE_TREE_IN_PROFILE = \"enable_show_predicate_tree_in_profile\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2878
+          context: "@VarAttr(name = ENABLE_SHOW_PREDICATE_TREE_IN_PROFILE, flag = VariableMgr.INVISIBLE) private boolean enableShowPredicateTreeInProfile = false"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Debug trace parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_query_debug_trace"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to enable debug tracing for queries. Writes detailed
+      execution trace to the query_debug_trace_dir. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 621
+          context: "public static final String ENABLE_QUERY_DEBUG_TRACE = \"enable_query_debug_trace\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1931
+          context: "@VariableMgr.VarAttr(name = ENABLE_QUERY_DEBUG_TRACE, flag = VariableMgr.INVISIBLE) private boolean enableQueryDebugTrace = false"
+      thrift_propagation: null
+
+  - name: "trace_log_mode"
+    type: String
+    default: "command"
+    scope: "session"
+    mutable: true
+    description: >
+      Mode for trace logging output. Controls where trace logs are
+      written. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 608
+          context: "public static final String TRACE_LOG_MODE = \"trace_log_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1935
+          context: "@VarAttr(name = TRACE_LOG_MODE, flag = VariableMgr.INVISIBLE) private String traceLogMode = \"command\""
+      thrift_propagation: null
+
+  - name: "trace_log_level"
+    type: int
+    default: 0
+    scope: "session"
+    mutable: true
+    description: >
+      Verbosity level for trace logging. Higher values produce more
+      detailed output. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 609
+          context: "public static final String TRACE_LOG_LEVEL = \"trace_log_level\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1939
+          context: "@VarAttr(name = TRACE_LOG_LEVEL, flag = VariableMgr.INVISIBLE) private int traceLogLevel = 0"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # Big query logging parameters
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_big_query_log"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to log big queries that exceed CPU, scan bytes, or scan
+      rows thresholds. Helps identify resource-intensive queries.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 824
+          context: "public static final String ENABLE_BIG_QUERY_LOG = \"enable_big_query_log\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2785
+          context: "@VarAttr(name = ENABLE_BIG_QUERY_LOG) private boolean enableBigQueryLog = true"
+      thrift_propagation: null
+
+  - name: "big_query_log_cpu_second_threshold"
+    type: long
+    default: 480
+    scope: "session"
+    mutable: true
+    description: >
+      CPU time threshold in seconds for big query logging. Queries
+      consuming more CPU time than this are logged as big queries.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 825
+          context: "public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = \"big_query_log_cpu_second_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2791
+          context: "@VarAttr(name = BIG_QUERY_LOG_CPU_SECOND_THRESHOLD) private long bigQueryLogCPUSecondThreshold = 480"
+      thrift_propagation: null
+
+  - name: "big_query_log_scan_bytes_threshold"
+    type: long
+    default: 10737418240
+    scope: "session"
+    mutable: true
+    description: >
+      Scan bytes threshold for big query logging. Queries scanning more
+      than this amount (default 10 GB) are logged as big queries.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 826
+          context: "public static final String BIG_QUERY_LOG_SCAN_BYTES_THRESHOLD = \"big_query_log_scan_bytes_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2795
+          context: "@VarAttr(name = BIG_QUERY_LOG_SCAN_BYTES_THRESHOLD) private long bigQueryLogScanBytesThreshold = 1024L * 1024 * 1024 * 10"
+      thrift_propagation: null
+
+  - name: "big_query_log_scan_rows_threshold"
+    type: long
+    default: 1000000000
+    scope: "session"
+    mutable: true
+    description: >
+      Scan rows threshold for big query logging. Queries scanning more
+      than 1 billion rows are logged as big queries.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 827
+          context: "public static final String BIG_QUERY_LOG_SCAN_ROWS_THRESHOLD = \"big_query_log_scan_rows_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2800
+          context: "@VarAttr(name = BIG_QUERY_LOG_SCAN_ROWS_THRESHOLD) private long bigQueryLogScanRowsThreshold = 1000000000L"
+      thrift_propagation: null
+
+  # ---------------------------------------------------------------------------
+  # SQL dialect and debug options
+  # ---------------------------------------------------------------------------
+
+  - name: "sql_dialect"
+    type: String
+    default: "StarRocks"
+    scope: "session"
+    mutable: true
+    description: >
+      SQL dialect to use for parsing and execution. Controls
+      compatibility behavior for SQL syntax from other databases.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 830
+          context: "public static final String SQL_DIALECT = \"sql_dialect\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2803
+          context: "@VarAttr(name = SQL_DIALECT) private String sqlDialect = \"StarRocks\""
+      thrift_propagation: null
+
+  - name: "query_debug_options"
+    type: String
+    default: ""
+    scope: "session"
+    mutable: true
+    description: >
+      Comma-separated debug options for query execution. Used for
+      internal debugging and testing. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 395
+          context: "public static final String QUERY_DEBUG_OPTIONS = \"query_debug_options\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1747
+          context: "@VariableMgr.VarAttr(name = QUERY_DEBUG_OPTIONS, flag = VariableMgr.INVISIBLE) private String queryDebugOptions = \"\""
+      thrift_propagation: null
+
+  - name: "enable_optimizer_rule_debug"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to output debug information about optimizer rule
+      applications during query planning.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 894
+          context: "public static final String ENABLE_OPTIMIZER_RULE_DEBUG = \"enable_optimizer_rule_debug\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2866
+          context: "@VarAttr(name = ENABLE_OPTIMIZER_RULE_DEBUG) private boolean enableOptimizerRuleDebug = false"
+      thrift_propagation: null
+
+  - name: "enable_strict_type"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to enable strict type checking mode that rejects implicit
+      type conversions that could lose precision. Invisible session variable.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 896
+          context: "public static final String ENABLE_STRICT_TYPE = \"enable_strict_type\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3476
+          context: "@VarAttr(name = ENABLE_STRICT_TYPE, flag = VariableMgr.INVISIBLE) private boolean enableStrictType = false"
+      thrift_propagation: null
+
+# =============================================================================
+# BE Configs - Logging and Debugging
+# =============================================================================
+
+be_configs:
+
+  - name: "sys_log_dir"
+    type: String
+    default: "${STARROCKS_HOME}/log"
+    scope: "BE"
+    mutable: false
+    description: >
+      Directory for BE system log files (be.INFO, be.WARNING, be.ERROR).
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 214
+          context: "CONF_String(sys_log_dir, \"${STARROCKS_HOME}/log\")"
+      thrift_propagation: null
+
+  - name: "sys_log_level"
+    type: String
+    default: "INFO"
+    scope: "BE"
+    mutable: true
+    description: >
+      Minimum log level for BE system logs. Options: INFO, WARNING,
+      ERROR, FATAL.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 220
+          context: "CONF_mString(sys_log_level, \"INFO\")"
+      thrift_propagation: null
+
+  - name: "sys_log_roll_mode"
+    type: String
+    default: "SIZE-MB-1024"
+    scope: "BE"
+    mutable: false
+    description: >
+      Log rotation mode. SIZE-MB-N rotates when file reaches N MB.
+      Default rotates at 1 GB.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 222
+          context: "CONF_String(sys_log_roll_mode, \"SIZE-MB-1024\")"
+      thrift_propagation: null
+
+  - name: "sys_log_roll_num"
+    type: Int32
+    default: 10
+    scope: "BE"
+    mutable: false
+    description: >
+      Maximum number of rotated log files to keep per log level.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 224
+          context: "CONF_Int32(sys_log_roll_num, \"10\")"
+      thrift_propagation: null
+
+  - name: "profile_report_interval"
+    type: Int32
+    default: 30
+    scope: "BE"
+    mutable: true
+    description: >
+      Interval in seconds between profile report submissions from
+      BE to FE during query execution.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 304
+          context: "CONF_mInt32(profile_report_interval, \"30\")"
+      thrift_propagation: null
+
+  - name: "compaction_trace_threshold"
+    type: Int32
+    default: 60
+    scope: "BE"
+    mutable: true
+    description: >
+      Time threshold in seconds above which compaction operations
+      are traced in the log for performance investigation.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 418
+          context: "CONF_mInt32(compaction_trace_threshold, \"60\")"
+      thrift_propagation: null
+
+  - name: "load_error_log_reserve_hours"
+    type: Int64
+    default: 48
+    scope: "BE"
+    mutable: true
+    description: >
+      Number of hours to retain load error log files before automatic
+      cleanup. Default is 48 hours.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 518
+          context: "CONF_mInt64(load_error_log_reserve_hours, \"48\")"
+      thrift_propagation: null
+
+  - name: "query_debug_trace_dir"
+    type: String
+    default: "${STARROCKS_HOME}/query_debug_trace"
+    scope: "BE"
+    mutable: false
+    description: >
+      Directory for storing query debug trace output files generated
+      when enable_query_debug_trace is enabled.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1206
+          context: "CONF_String(query_debug_trace_dir, \"${STARROCKS_HOME}/query_debug_trace\")"
+      thrift_propagation: null
+
+  - name: "pipeline_print_profile"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: true
+    description: >
+      Whether to print pipeline execution profiles to the BE log.
+      Useful for debugging pipeline execution issues.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1006
+          context: "CONF_mBool(pipeline_print_profile, \"false\")"
+      thrift_propagation: null
+
+  - name: "pipeline_timeout_diagnostic"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: true
+    description: >
+      Whether to enable diagnostic logging when pipeline execution
+      times out. Helps identify the cause of stuck pipelines.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1007
+          context: "CONF_mBool(pipeline_timeout_diagnostic, \"false\")"
+      thrift_propagation: null
+
+  - name: "aws_sdk_logging_trace_enabled"
+    type: boolean
+    default: false
+    scope: "BE"
+    mutable: true
+    description: >
+      Whether to enable AWS SDK trace-level logging. Produces very
+      verbose output for debugging S3/object storage issues.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 1158
+          context: "CONF_mBool(aws_sdk_logging_trace_enabled, \"false\")"
+      thrift_propagation: null
+
+  - name: "status_report_interval"
+    type: Int32
+    default: 5
+    scope: "BE"
+    mutable: true
+    description: >
+      Interval in seconds between status reports from fragment
+      instances to the coordinator during query execution.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 265
+          context: "CONF_mInt32(status_report_interval, \"5\")"
+      thrift_propagation: null

--- a/param-docs/13_general_system.yml
+++ b/param-docs/13_general_system.yml
@@ -1,0 +1,1530 @@
+# =============================================================================
+# StarRocks General / System Parameters (Catch-All)
+# Source: fe/.../qe/SessionVariable.java, be/src/common/config.h
+#
+# Parameters that do not fit into the 12 specialized categories:
+#   01 query_optimization, 02 join_optimization, 03 scan_and_io,
+#   04 parquet_orc_reader, 05 memory_management, 06 parallelism_scheduling,
+#   07 materialized_views, 08 external_catalogs, 09 network_timeout,
+#   10 statistics_cost_estimation, 11 security_authentication,
+#   12 logging_debugging
+# =============================================================================
+
+session_variables:
+
+  # ---------------------------------------------------------------------------
+  # Character set and collation (MySQL-compat stubs)
+  # ---------------------------------------------------------------------------
+
+  - name: "character_set_client"
+    type: string
+    default: "utf8"
+    scope: "session"
+    mutable: true
+    description: >
+      Character set for statements arriving from the client. MySQL-compatible
+      stub; StarRocks only supports utf8.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 196
+          context: "public static final String CHARACTER_SET_CLIENT = \"character_set_client\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1321
+          context: "@VarAttr(name = CHARACTER_SET_CLIENT) private String charsetClient = \"utf8\""
+
+  - name: "character_set_connection"
+    type: string
+    default: "utf8"
+    scope: "session"
+    mutable: true
+    description: >
+      Character set used for literals that do not have a character set
+      introducer and for number-to-string conversion. MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 197
+          context: "public static final String CHARACTER_SET_CONNNECTION = \"character_set_connection\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1323
+          context: "@VarAttr(name = CHARACTER_SET_CONNNECTION) private String charsetConnection = \"utf8\""
+
+  - name: "character_set_results"
+    type: string
+    default: "utf8"
+    scope: "session"
+    mutable: true
+    description: >
+      Character set used for returning query results to the client.
+      MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 198
+          context: "public static final String CHARACTER_SET_RESULTS = \"character_set_results\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1325
+          context: "@VarAttr(name = CHARACTER_SET_RESULTS) private String charsetResults = \"utf8\""
+
+  - name: "character_set_server"
+    type: string
+    default: "utf8"
+    scope: "session"
+    mutable: true
+    description: >
+      Server default character set. MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 199
+          context: "public static final String CHARACTER_SET_SERVER = \"character_set_server\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1327
+          context: "@VarAttr(name = CHARACTER_SET_SERVER) private String charsetServer = \"utf8\""
+
+  - name: "collation_connection"
+    type: string
+    default: "utf8_general_ci"
+    scope: "session"
+    mutable: true
+    description: >
+      Collation of the connection character set. MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 200
+          context: "public static final String COLLATION_CONNECTION = \"collation_connection\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1329
+          context: "@VarAttr(name = COLLATION_CONNECTION) private String collationConnection = \"utf8_general_ci\""
+
+  - name: "collation_database"
+    type: string
+    default: "utf8_general_ci"
+    scope: "session"
+    mutable: true
+    description: >
+      Collation used by the default database. MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 201
+          context: "public static final String COLLATION_DATABASE = \"collation_database\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1331
+          context: "@VarAttr(name = COLLATION_DATABASE) private String collationDatabase = \"utf8_general_ci\""
+
+  - name: "collation_server"
+    type: string
+    default: "utf8_general_ci"
+    scope: "session"
+    mutable: true
+    description: >
+      Server default collation. MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 202
+          context: "public static final String COLLATION_SERVER = \"collation_server\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1333
+          context: "@VarAttr(name = COLLATION_SERVER) private String collationServer = \"utf8_general_ci\""
+
+  # ---------------------------------------------------------------------------
+  # Timezone
+  # ---------------------------------------------------------------------------
+
+  - name: "time_zone"
+    type: string
+    default: "(system timezone)"
+    scope: "session"
+    mutable: true
+    description: >
+      Session time zone used for DATETIME display and timezone-aware functions.
+      Accepts IANA zone names (e.g. "Asia/Shanghai") or UTC offsets ("+08:00").
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 214
+          context: "public static final String TIME_ZONE = \"time_zone\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1373
+          context: "@VarAttr(name = TIME_ZONE) private String timeZone = TimeUtils.getSystemTimeZone().getID()"
+
+  # ---------------------------------------------------------------------------
+  # Transaction and autocommit
+  # ---------------------------------------------------------------------------
+
+  - name: "autocommit"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether each SQL statement is automatically committed. StarRocks
+      defaults to autocommit mode; setting to false is meaningful only when
+      SQL transaction support is enabled.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 185
+          context: "public static final String AUTO_COMMIT = \"autocommit\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1286
+          context: "@VarAttr(name = AUTO_COMMIT) private boolean autoCommit = true"
+
+  - name: "enable_sql_transaction"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Enable SQL transaction capability. When false, BEGIN/COMMIT/ROLLBACK
+      syntax is accepted but transaction behavior is not enforced.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 191
+          context: "public static final String ENABLE_SQL_TRANSACTION = \"enable_sql_transaction\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1289
+          context: "@VarAttr(name = ENABLE_SQL_TRANSACTION) private boolean enableSqlTransaction = true"
+
+  - name: "tx_isolation"
+    type: string
+    default: "REPEATABLE-READ"
+    scope: "session"
+    mutable: true
+    description: >
+      Transaction isolation level. MySQL-compatible; StarRocks supports
+      REPEATABLE-READ semantics. Alias for transaction_isolation.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 186
+          context: "public static final String TX_ISOLATION = \"tx_isolation\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1301
+          context: "@VarAttr(name = TX_ISOLATION) private String txIsolation = \"REPEATABLE-READ\""
+
+  - name: "transaction_isolation"
+    type: string
+    default: "REPEATABLE-READ"
+    scope: "session"
+    mutable: true
+    description: >
+      Transaction isolation level (standard MySQL 8.0+ name). Same as
+      tx_isolation.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 188
+          context: "public static final String TRANSACTION_ISOLATION = \"transaction_isolation\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1305
+          context: "@VarAttr(name = TRANSACTION_ISOLATION) private String transactionIsolation = \"REPEATABLE-READ\""
+
+  - name: "transaction_read_only"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether the current transaction is read-only. Alias: tx_read_only.
+      MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 189
+          context: "public static final String TRANSACTION_READ_ONLY = \"transaction_read_only\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1307
+          context: "@VarAttr(name = TRANSACTION_READ_ONLY, alias = TX_READ_ONLY) private boolean transactionReadOnly = false"
+
+  # ---------------------------------------------------------------------------
+  # MySQL-compat metadata stubs
+  # ---------------------------------------------------------------------------
+
+  - name: "auto_increment_increment"
+    type: integer
+    default: 1
+    scope: "session"
+    mutable: true
+    description: >
+      Controls the increment between successive AUTO_INCREMENT values.
+      MySQL-compatible stub.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 206
+          context: "public static final String AUTO_INCREMENT_INCREMENT = \"auto_increment_increment\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1349
+          context: "@VarAttr(name = AUTO_INCREMENT_INCREMENT) private int autoIncrementIncrement = 1"
+
+  - name: "query_cache_type"
+    type: integer
+    default: 0
+    scope: "session"
+    mutable: true
+    description: >
+      MySQL-compatible stub for query cache type. 0 = OFF. Not related to
+      StarRocks' own query cache feature (enable_query_cache).
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 207
+          context: "public static final String QUERY_CACHE_TYPE = \"query_cache_type\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1353
+          context: "@VarAttr(name = QUERY_CACHE_TYPE) private int queryCacheType = 0"
+
+  - name: "SQL_AUTO_IS_NULL"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      MySQL-compatible stub. When true, the last inserted AUTO_INCREMENT
+      value can be retrieved with WHERE col IS NULL. Has no effect in
+      StarRocks.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 203
+          context: "public static final String SQL_AUTO_IS_NULL = \"SQL_AUTO_IS_NULL\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1337
+          context: "@VarAttr(name = SQL_AUTO_IS_NULL) private boolean sqlAutoIsNull = false"
+
+  - name: "sql_select_limit"
+    type: long
+    default: 9223372036854775807
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum number of rows to return from SELECT. Default is effectively
+      unlimited (Long.MAX_VALUE). MySQL-compatible.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 204
+          context: "public static final String SQL_SELECT_LIMIT = \"sql_select_limit\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1341
+          context: "@VarAttr(name = SQL_SELECT_LIMIT) private long sqlSelectLimit = DEFAULT_SELECT_LIMIT"
+
+  - name: "innodb_read_only"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      MySQL-compatible stub. Always true in StarRocks (no InnoDB engine).
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 215
+          context: "public static final String INNODB_READ_ONLY = \"innodb_read_only\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1376
+          context: "@VarAttr(name = INNODB_READ_ONLY) private boolean innodbReadOnly = true"
+
+  - name: "event_scheduler"
+    type: string
+    default: "OFF"
+    scope: "session"
+    mutable: true
+    description: >
+      MySQL-compatible stub for the event scheduler state. Has no effect
+      in StarRocks.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 267
+          context: "public static final String EVENT_SCHEDULER = \"event_scheduler\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1666
+          context: "@VarAttr(name = EVENT_SCHEDULER) private String eventScheduler = \"OFF\""
+
+  - name: "storage_engine"
+    type: string
+    default: "olap"
+    scope: "session"
+    mutable: true
+    description: >
+      Default storage engine name exposed for MySQL compatibility. Value is
+      "olap" in StarRocks.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 268
+          context: "public static final String STORAGE_ENGINE = \"storage_engine\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1668
+          context: "@VarAttr(name = STORAGE_ENGINE) private String storageEngine = \"olap\""
+
+  - name: "default_storage_engine"
+    type: string
+    default: "InnoDB"
+    scope: "session"
+    mutable: true
+    description: >
+      MySQL-compatible stub for default storage engine. Reports "InnoDB"
+      for driver compatibility.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 192
+          context: "public static final String DEFAULT_STORAGE_ENGINE = \"default_storage_engine\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1311
+          context: "@VarAttr(name = DEFAULT_STORAGE_ENGINE) private String defaultStorageEngine = \"InnoDB\""
+
+  - name: "default_tmp_storage_engine"
+    type: string
+    default: "InnoDB"
+    scope: "session"
+    mutable: true
+    description: >
+      MySQL-compatible stub for default temporary table storage engine.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 193
+          context: "public static final String DEFAULT_TMP_STORAGE_ENGINE = \"default_tmp_storage_engine\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1313
+          context: "@VarAttr(name = DEFAULT_TMP_STORAGE_ENGINE) private String defaultTmpStorageEngine = \"InnoDB\""
+
+  - name: "foreign_key_checks"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    deprecated: true
+    description: >
+      MySQL-compatible stub for foreign key constraint checking. Only for
+      Aliyun DTS compatibility; has no actual effect. Deprecated.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 380
+          context: "public static final String FOREIGN_KEY_CHECKS = \"foreign_key_checks\""
+
+  # ---------------------------------------------------------------------------
+  # Numeric precision and overflow
+  # ---------------------------------------------------------------------------
+
+  - name: "div_precision_increment"
+    type: integer
+    default: 4
+    scope: "session"
+    mutable: true
+    description: >
+      Number of digits by which to increase the scale of the result of
+      division operations. MySQL-compatible.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 269
+          context: "public static final String DIV_PRECISION_INCREMENT = \"div_precision_increment\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1670
+          context: "@VarAttr(name = DIV_PRECISION_INCREMENT) private int divPrecisionIncrement = 4"
+
+  - name: "decimal_overflow_to_double"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      When true, decimal computations that overflow the maximum precision
+      are automatically promoted to DOUBLE instead of returning an error.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 270
+          context: "public static final String DECIMAL_OVERFLOW_TO_DOUBLE = \"decimal_overflow_to_double\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1673
+          context: "@VarAttr(name = DECIMAL_OVERFLOW_TO_DOUBLE) private boolean decimalOverflowToDouble = false"
+
+  - name: "large_decimal_underlying_type"
+    type: string
+    default: "panic"
+    scope: "session"
+    mutable: true
+    description: >
+      Controls behavior when a DECIMAL literal exceeds Decimal128 range.
+      "panic" raises an error; "double" converts to DOUBLE; "decimal"
+      keeps it as wider decimal.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 708
+          context: "public static final String LARGE_DECIMAL_UNDERLYING_TYPE = \"large_decimal_underlying_type\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3072
+          context: "@VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE) private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC"
+
+  # ---------------------------------------------------------------------------
+  # Compression and encoding
+  # ---------------------------------------------------------------------------
+
+  - name: "default_table_compression"
+    type: string
+    default: "lz4_frame"
+    scope: "session"
+    mutable: true
+    description: >
+      Default compression algorithm for newly created tables. Supported:
+      lz4_frame, snappy, zstd, zlib, lz4, none.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 559
+          context: "public static final String DEFAULT_TABLE_COMPRESSION = \"default_table_compression\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1922
+          context: "@VarAttr(name = DEFAULT_TABLE_COMPRESSION) private String defaultTableCompressionAlgorithm = \"lz4_frame\""
+
+  - name: "transmission_compression_type"
+    type: string
+    default: "AUTO"
+    scope: "session"
+    mutable: true
+    description: >
+      Compression algorithm for data transmitted between FE/BE nodes during
+      query execution (shuffle data). "AUTO" selects based on network
+      conditions; explicit values: NO_COMPRESSION, LZ4, SNAPPY, ZSTD, GZIP.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 498
+          context: "public static final String TRANSMISSION_COMPRESSION_TYPE = \"transmission_compression_type\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1809
+          context: "@VarAttr(name = TRANSMISSION_COMPRESSION_TYPE) private String transmissionCompressionType = \"AUTO\""
+
+  - name: "load_transmission_compression_type"
+    type: string
+    default: "NO_COMPRESSION"
+    scope: "session"
+    mutable: true
+    description: >
+      Compression algorithm for data transmitted during load operations.
+      Defaults to no compression; same options as transmission_compression_type.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 499
+          context: "public static final String LOAD_TRANSMISSION_COMPRESSION_TYPE = \"load_transmission_compression_type\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1834
+          context: "@VarAttr(name = LOAD_TRANSMISSION_COMPRESSION_TYPE) private String loadTransmissionCompressionType = \"NO_COMPRESSION\""
+
+  # ---------------------------------------------------------------------------
+  # Load / insert behavior
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_insert_strict"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether INSERT operations perform strict data quality checks. When
+      enabled, rows that violate column constraints (type mismatch, NULL
+      into NOT NULL, etc.) cause the INSERT to fail rather than being
+      silently filtered.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 227
+          context: "public static final String ENABLE_INSERT_STRICT = \"enable_insert_strict\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1547
+          context: "@VarAttr(name = ENABLE_INSERT_STRICT) private boolean enableInsertStrict = true"
+
+  - name: "insert_max_filter_ratio"
+    type: double
+    default: 0
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum ratio (0-1) of rows that can be filtered during INSERT before
+      the operation is considered failed. 0 means any filtered row causes
+      failure.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 228
+          context: "public static final String INSERT_MAX_FILTER_RATIO = \"insert_max_filter_ratio\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1553
+          context: "@VarAttr(name = INSERT_MAX_FILTER_RATIO) private double insertMaxFilterRatio = 0"
+
+  - name: "dynamic_overwrite"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether INSERT OVERWRITE uses dynamic partition overwrite semantics.
+      When true, only partitions that have data in the source are replaced;
+      other partitions are left untouched.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 230
+          context: "public static final String DYNAMIC_OVERWRITE = \"dynamic_overwrite\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1550
+          context: "@VarAttr(name = DYNAMIC_OVERWRITE) private boolean dynamicOverwrite = false"
+
+  - name: "partial_update_mode"
+    type: string
+    default: "auto"
+    scope: "session"
+    mutable: true
+    description: >
+      Partial update strategy for Primary Key tables. "auto" lets the
+      system choose; "row" uses row-mode partial update; "column" uses
+      column-mode partial update.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 898
+          context: "public static final String PARTIAL_UPDATE_MODE = \"partial_update_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2063
+          context: "@VarAttr(name = PARTIAL_UPDATE_MODE) private String partialUpdateMode = \"auto\""
+
+  - name: "enable_insert_partial_update"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether INSERT INTO on Primary Key tables uses partial update logic
+      (only updating the specified columns instead of full-row upsert).
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 900
+          context: "public static final String ENABLE_INSERT_PARTIAL_UPDATE = \"enable_insert_partial_update\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2066
+          context: "@VarAttr(name = ENABLE_INSERT_PARTIAL_UPDATE) private boolean enableInsertPartialUpdate = true"
+
+  - name: "log_rejected_record_num"
+    type: long
+    default: 0
+    scope: "session"
+    mutable: true
+    description: >
+      Number of rejected/filtered records to log during load operations.
+      0 means no rejected records are logged.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 312
+          context: "public static final String LOG_REJECTED_RECORD_NUM = \"log_rejected_record_num\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1164
+          context: "@VarAttr(name = LOG_REJECTED_RECORD_NUM) private long logRejectedRecordNum = 0"
+
+  # ---------------------------------------------------------------------------
+  # Query behavior and plan control
+  # ---------------------------------------------------------------------------
+
+  - name: "enable_strict_order_by"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      When true, ORDER BY columns must be unambiguous. Prevents
+      non-deterministic orderings when column references are ambiguous.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 716
+          context: "public static final String ENABLE_STRICT_ORDER_BY = \"enable_strict_order_by\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3240
+          context: "@VarAttr(name = ENABLE_STRICT_ORDER_BY) private boolean enableStrictOrderBy = true"
+
+  - name: "group_concat_max_len"
+    type: long
+    default: 1024
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum length (in bytes) of the result of the GROUP_CONCAT function.
+      Outputs exceeding this length are truncated.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 849
+          context: "public static final String GROUP_CONCAT_MAX_LEN = \"group_concat_max_len\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2832
+          context: "@VarAttr(name = GROUP_CONCAT_MAX_LEN) private long groupConcatMaxLen = 1024"
+
+  - name: "streaming_preaggregation_mode"
+    type: string
+    default: "auto"
+    scope: "session"
+    mutable: true
+    description: >
+      Strategy for streaming pre-aggregation in the execution engine.
+      "auto" lets the optimizer decide; "force_streaming" always streams;
+      "force_preaggregation" always pre-aggregates.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 221
+          context: "public static final String STREAMING_PREAGGREGATION_MODE = \"streaming_preaggregation_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1393
+          context: "@VarAttr(name = STREAMING_PREAGGREGATION_MODE) private String streamingPreaggregationMode = SessionVariableConstants.AUTO"
+
+  - name: "resource_group"
+    type: string
+    default: ""
+    scope: "session"
+    mutable: true
+    description: >
+      Name of the resource group (workgroup) to use for the current session.
+      An empty string means no specific resource group is assigned.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 184
+          context: "public static final String RESOURCE_GROUP = \"resource_group\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1282
+          context: "@VarAttr(name = RESOURCE_GROUP, flag = VariableMgr.SESSION_ONLY) private String resourceGroup = \"\""
+
+  - name: "enable_plan_serialize_concurrently"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to serialize query plan fragments concurrently when
+      distributing them to BEs. Reduces planning latency for queries with
+      many fragments.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 714
+          context: "public static final String ENABLE_PLAN_SERIALIZE_CONCURRENTLY = \"enable_plan_serialize_concurrently\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3231
+          context: "@VarAttr(name = ENABLE_PLAN_SERIALIZE_CONCURRENTLY) private boolean enablePlanSerializeConcurrently = true"
+
+  - name: "forward_to_leader"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to forward certain statements (e.g. SHOW, metadata queries) to
+      the leader FE to ensure consistent results. Alias: forward_to_master.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 263
+          context: "public static final String FORWARD_TO_LEADER = \"forward_to_leader\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1662
+          context: "@VarAttr(name = FORWARD_TO_LEADER, alias = FORWARD_TO_MASTER) private boolean forwardToLeader = false"
+
+  - name: "follower_query_forward_mode"
+    type: string
+    default: ""
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Controls whether a follower FE proxies queries to leader or serves
+      them locally. "" (default) decides by replay progress; "FOLLOWER"
+      always serves locally; "LEADER" always proxies to leader.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 757
+          context: "public static final String FOLLOWER_QUERY_FORWARD_MODE = \"follower_query_forward_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3237
+          context: "@VarAttr(name = FOLLOWER_QUERY_FORWARD_MODE, flag = INVISIBLE | DISABLE_FORWARD_TO_LEADER) private String followerForwardMode = \"\""
+
+  - name: "parse_tokens_limit"
+    type: integer
+    default: 3500000
+    scope: "session"
+    mutable: true
+    description: >
+      Maximum number of tokens the SQL parser will process before aborting.
+      Protects against extremely large SQL statements consuming excessive
+      memory or CPU.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 627
+          context: "public static final String PARSE_TOKENS_LIMIT = \"parse_tokens_limit\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1996
+          context: "@VarAttr(name = PARSE_TOKENS_LIMIT) private int parseTokensLimit = 3500000"
+
+  - name: "enable_sql_digest"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Whether to compute and store SQL digest (normalized fingerprint) for
+      queries. Used for statement analysis and grouping.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 435
+          context: "public static final String ENABLE_SQL_DIGEST = \"enable_sql_digest\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1447
+          context: "@VarAttr(name = ENABLE_SQL_DIGEST, flag = INVISIBLE) private boolean enableSQLDigest = false"
+
+  - name: "enable_show_all_variables"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      When true, SHOW VARIABLES displays all variables including invisible
+      and internal ones.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 619
+          context: "public static final String ENABLE_SHOW_ALL_VARIABLES = \"enable_show_all_variables\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1957
+          context: "@VarAttr(name = ENABLE_SHOW_ALL_VARIABLES, flag = INVISIBLE) private boolean enableShowAllVariables = false"
+
+  - name: "sql_quote_show_create"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether SHOW CREATE TABLE quotes identifiers. MySQL-compatible.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 890
+          context: "public static final String SQL_QUOTE_SHOW_CREATE = \"sql_quote_show_create\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2829
+          context: "@VarAttr(name = SQL_QUOTE_SHOW_CREATE) private boolean quoteShowCreate = true"
+
+  - name: "enable_color_explain_output"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether EXPLAIN output includes ANSI color codes for terminal display.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 171
+          context: "public static final String COLOR_EXPLAIN_OUTPUT = \"enable_color_explain_output\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1253
+          context: "@VarAttr(name = COLOR_EXPLAIN_OUTPUT) private boolean colorExplainOutput = true"
+
+  - name: "custom_query_id"
+    type: string
+    default: ""
+    scope: "session"
+    mutable: true
+    description: >
+      User-specified query ID override. When non-empty, this value is used
+      as the query ID instead of the auto-generated UUID.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 727
+          context: "public static final String CUSTOM_QUERY_ID = \"custom_query_id\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3333
+          context: "@VarAttr(name = CUSTOM_QUERY_ID, flag = SESSION_ONLY) private String customQueryId = \"\""
+
+  - name: "custom_session_name"
+    type: string
+    default: ""
+    scope: "session"
+    mutable: true
+    description: >
+      User-specified session name for identification in logs and profiles.
+      Maximum 64 characters.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 747
+          context: "public static final String CUSTOM_SESSION_NAME = \"custom_session_name\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3336
+          context: "@VarAttr(name = CUSTOM_SESSION_NAME, flag = SESSION_ONLY) private String customSessionName = \"\""
+
+  - name: "enable_execution_only"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Execute SQL without returning results. Used for performance testing
+      to measure execution overhead without result serialization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 733
+          context: "public static final String ENABLE_EXECUTION_ONLY = \"enable_execution_only\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1514
+          context: "@VarAttr(name = ENABLE_EXECUTION_ONLY, flag = INVISIBLE) private boolean enableExecutionOnly = false"
+
+  - name: "enable_result_sink_accumulate"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    description: >
+      Whether the result sink accumulates data before sending to reduce
+      RPC overhead.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 719
+          context: "private static final String ENABLE_RESULT_SINK_ACCUMULATE = \"enable_result_sink_accumulate\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3090
+          context: "@VarAttr(name = ENABLE_RESULT_SINK_ACCUMULATE) private boolean enableResultSinkAccumulate = true"
+
+  - name: "enable_wait_dependent_event"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Enable waiting for dependent events in the pipeline scheduler.
+      Experimental feature for fine-grained scheduling control.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 721
+          context: "public static final String ENABLE_WAIT_DEPENDENT_EVENT = \"enable_wait_dependent_event\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3249
+          context: "@VarAttr(name = ENABLE_WAIT_DEPENDENT_EVENT) private boolean enableWaitDependentEvent = false"
+
+  # ---------------------------------------------------------------------------
+  # Deprecated session variables (kept for compatibility)
+  # ---------------------------------------------------------------------------
+
+  - name: "codegen_level"
+    type: integer
+    default: 0
+    scope: "session"
+    mutable: true
+    deprecated: true
+    description: >
+      Code generation level. Deprecated; StarRocks uses vectorized
+      execution instead of codegen.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 218
+          context: "public static final String CODEGEN_LEVEL = \"codegen_level\""
+
+  - name: "max_execution_time"
+    type: integer
+    default: 0
+    scope: "session"
+    mutable: true
+    deprecated: true
+    description: >
+      Deprecated alias for query_timeout. Use query_timeout instead.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 169
+          context: "public static final String MAX_EXECUTION_TIME = \"max_execution_time\""
+
+  - name: "profiling"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    deprecated: true
+    description: >
+      Deprecated MySQL-compatible stub. Use enable_profile instead.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 175
+          context: "public static final String PROFILING = \"profiling\""
+
+  # ---------------------------------------------------------------------------
+  # Miscellaneous query features
+  # ---------------------------------------------------------------------------
+
+  - name: "interpolate_passthrough"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Whether to pass through interpolate columns directly in ASOF joins
+      or similar time-series operations.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 623
+          context: "public static final String INTERPOLATE_PASSTHROUGH = \"interpolate_passthrough\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1942
+          context: "@VarAttr(name = INTERPOLATE_PASSTHROUGH, flag = INVISIBLE) private boolean interpolatePassthrough = true"
+
+  - name: "hash_join_interpolate_passthrough"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Whether hash join supports interpolate passthrough optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 625
+          context: "public static final String HASH_JOIN_INTERPOLATE_PASSTHROUGH = \"hash_join_interpolate_passthrough\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1945
+          context: "@VarAttr(name = HASH_JOIN_INTERPOLATE_PASSTHROUGH, flag = INVISIBLE) private boolean hashJoinInterpolatePassthrough = false"
+
+  - name: "window_partition_mode"
+    type: integer
+    default: 1
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Implementation mode for window function partitioning. 1 = sort-based,
+      2 = hash-based.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 644
+          context: "public static final String WINDOW_PARTITION_MODE = \"window_partition_mode\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2041
+          context: "@VarAttr(name = WINDOW_PARTITION_MODE, flag = INVISIBLE) private int windowPartitionMode = 1"
+
+  - name: "scan_or_to_union_limit"
+    type: integer
+    default: 4
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Maximum number of OR predicates on a scan that can be rewritten to
+      UNION ALL for parallel scan optimization.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 902
+          context: "public static final String SCAN_OR_TO_UNION_LIMIT = \"scan_or_to_union_limit\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2869
+          context: "@VarAttr(name = SCAN_OR_TO_UNION_LIMIT, flag = INVISIBLE) private int scanOrToUnionLimit = 4"
+
+  - name: "scan_or_to_union_threshold"
+    type: long
+    default: 50000000
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Row count threshold for the scan-OR-to-UNION rewrite. Only applies
+      the rewrite when estimated scan rows exceed this threshold.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 904
+          context: "public static final String SCAN_OR_TO_UNION_THRESHOLD = \"scan_or_to_union_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2872
+          context: "@VarAttr(name = SCAN_OR_TO_UNION_THRESHOLD, flag = INVISIBLE) private long scanOrToUnionThreshold = 50000000"
+
+  - name: "enable_pushdown_or_predicate"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Whether OR predicates can be pushed down to the storage layer for
+      filtering.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 906
+          context: "public static final String ENABLE_PUSHDOWN_OR_PREDICATE = \"enable_pushdown_or_predicate\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2875
+          context: "@VarAttr(name = ENABLE_PUSHDOWN_OR_PREDICATE, flag = INVISIBLE) private boolean enablePushdownOrPredicate = true"
+
+  - name: "select_ratio_threshold"
+    type: double
+    default: 0.15
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Selectivity ratio threshold used by the optimizer to decide whether
+      to push down predicates or use alternative plans.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 910
+          context: "public static final String SELECT_RATIO_THRESHOLD = \"select_ratio_threshold\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2884
+          context: "@VarAttr(name = SELECT_RATIO_THRESHOLD, flag = INVISIBLE) private double selectRatioThreshold = 0.15"
+
+  - name: "disable_function_fold_constants"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      When true, disables constant folding for functions during query
+      optimization. Useful for debugging.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 912
+          context: "public static final String DISABLE_FUNCTION_FOLD_CONSTANTS = \"disable_function_fold_constants\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2887
+          context: "@VarAttr(name = DISABLE_FUNCTION_FOLD_CONSTANTS, flag = INVISIBLE) private boolean disableFunctionFoldConstants = false"
+
+  - name: "enable_simplify_case_when"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Whether to simplify CASE WHEN expressions during optimization
+      (e.g. constant branch elimination).
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 914
+          context: "public static final String ENABLE_SIMPLIFY_CASE_WHEN = \"enable_simplify_case_when\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2890
+          context: "@VarAttr(name = ENABLE_SIMPLIFY_CASE_WHEN, flag = INVISIBLE) private boolean enableSimplifyCaseWhen = true"
+
+  - name: "enable_count_star_optimization"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Whether to optimize COUNT(*) queries by reading only metadata or
+      zone maps instead of full table scans.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 916
+          context: "public static final String ENABLE_COUNT_STAR_OPTIMIZATION = \"enable_count_star_optimization\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2893
+          context: "@VarAttr(name = ENABLE_COUNT_STAR_OPTIMIZATION, flag = INVISIBLE) private boolean enableCountStarOptimization = true"
+
+  - name: "enable_partition_column_value_only_optimization"
+    type: boolean
+    default: true
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      Enables optimization for queries that only read partition column
+      values, avoiding actual data scan by reading partition metadata.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 918
+          context: "public static final String ENABLE_PARTITION_COLUMN_VALUE_ONLY_OPTIMIZATION"
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2902
+          context: "@VarAttr(name = ENABLE_PARTITION_COLUMN_VALUE_ONLY_OPTIMIZATION, flag = INVISIBLE) private boolean enablePartitionColumnValueOnlyOptimization = true"
+
+  - name: "enable_fine_grained_range_predicate"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    description: >
+      Whether to use fine-grained range predicates for more precise
+      partition pruning and data skipping.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 717
+          context: "private static final String ENABLE_FINE_GRAINED_RANGE_PREDICATE = \"enable_fine_grained_range_predicate\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 3078
+          context: "@VarAttr(name = ENABLE_FINE_GRAINED_RANGE_PREDICATE) private boolean enableFineGrainedRangePredicate = false"
+
+  - name: "disable_generated_column_rewrite"
+    type: boolean
+    default: false
+    scope: "session"
+    mutable: true
+    flag: INVISIBLE
+    description: >
+      When true, disables the optimizer rewrite that replaces expressions
+      matching generated column definitions with direct column reads.
+    code_references:
+      definition:
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 1030
+          context: "public static final String DISABLE_GENERATED_COLUMN_REWRITE = \"disable_generated_column_rewrite\""
+        - file: "fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java"
+          line: 2112
+          context: "@VarAttr(name = DISABLE_GENERATED_COLUMN_REWRITE, flag = INVISIBLE) private boolean disableGeneratedColumnRewrite = false"
+
+# =============================================================================
+# BE configuration parameters (be/src/common/config.h)
+# =============================================================================
+
+be_config:
+
+  # ---------------------------------------------------------------------------
+  # BE server identity and ports
+  # ---------------------------------------------------------------------------
+
+  - name: "cluster_id"
+    type: Int32
+    default: -1
+    scope: "BE config"
+    mutable: false
+    description: >
+      Cluster identifier. -1 means auto-assigned by the FE during first
+      heartbeat. Should not be changed manually.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 41
+          context: "CONF_Int32(cluster_id, \"-1\")"
+
+  - name: "be_port"
+    type: Int32
+    default: 9060
+    scope: "BE config"
+    mutable: false
+    description: >
+      Thrift RPC port for the BE service. FE uses this port to communicate
+      with BE nodes.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 43
+          context: "CONF_Int32(be_port, \"9060\")"
+
+  - name: "storage_root_path"
+    type: String
+    default: "${STARROCKS_HOME}/storage"
+    scope: "BE config"
+    mutable: false
+    description: >
+      Root directory path for local data storage. Multiple paths can be
+      separated by semicolons. Each path can optionally specify storage
+      medium and capacity.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 306
+          context: "CONF_String(storage_root_path, \"${STARROCKS_HOME}/storage\")"
+
+  - name: "max_tablet_num_per_shard"
+    type: Int32
+    default: 1024
+    scope: "BE config"
+    mutable: false
+    description: >
+      Maximum number of tablets per shard directory. Controls the
+      directory structure for tablet data files.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 312
+          context: "CONF_Int32(max_tablet_num_per_shard, \"1024\")"
+
+  - name: "storage_format_version"
+    type: Int16
+    default: 2
+    scope: "BE config"
+    mutable: true
+    description: >
+      Storage format version. Version 1 uses legacy Date/Datetime/Decimal
+      types; version 2 uses DATE_V2, TIMESTAMP, and DECIMAL_V2 as the
+      storage format. Only 1 and 2 are valid.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 926
+          context: "CONF_mInt16(storage_format_version, \"2\")"
+
+  # ---------------------------------------------------------------------------
+  # Compaction threads
+  # ---------------------------------------------------------------------------
+
+  - name: "base_compaction_num_threads_per_disk"
+    type: Int32
+    default: 1
+    scope: "BE config"
+    mutable: false
+    description: >
+      Number of base compaction threads per disk. Controls parallelism of
+      base compaction operations.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 362
+          context: "CONF_Int32(base_compaction_num_threads_per_disk, \"1\")"
+
+  - name: "cumulative_compaction_num_threads_per_disk"
+    type: Int32
+    default: 1
+    scope: "BE config"
+    mutable: false
+    description: >
+      Number of cumulative compaction threads per disk.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 372
+          context: "CONF_Int32(cumulative_compaction_num_threads_per_disk, \"1\")"
+
+  - name: "base_compaction_check_interval_seconds"
+    type: Int32
+    default: 60
+    scope: "BE config"
+    mutable: true
+    description: >
+      Interval in seconds between base compaction eligibility checks.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 357
+          context: "CONF_mInt32(base_compaction_check_interval_seconds, \"60\")"
+
+  - name: "cumulative_compaction_check_interval_seconds"
+    type: Int32
+    default: 1
+    scope: "BE config"
+    mutable: true
+    description: >
+      Interval in seconds between cumulative compaction eligibility checks.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 367
+          context: "CONF_mInt32(cumulative_compaction_check_interval_seconds, \"1\")"
+
+  - name: "min_base_compaction_num_singleton_deltas"
+    type: Int64
+    default: 5
+    scope: "BE config"
+    mutable: true
+    description: >
+      Minimum number of singleton delta rowsets required before a base
+      compaction is triggered.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 358
+          context: "CONF_mInt64(min_base_compaction_num_singleton_deltas, \"5\")"
+
+  - name: "max_base_compaction_num_singleton_deltas"
+    type: Int64
+    default: 100
+    scope: "BE config"
+    mutable: true
+    description: >
+      Maximum number of singleton delta rowsets that can be included in
+      a single base compaction.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 359
+          context: "CONF_mInt64(max_base_compaction_num_singleton_deltas, \"100\")"
+
+  - name: "base_compaction_interval_seconds_since_last_operation"
+    type: Int64
+    default: 86400
+    scope: "BE config"
+    mutable: true
+    description: >
+      Minimum interval in seconds since the last base compaction before
+      triggering another one. Default is 24 hours.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 364
+          context: "CONF_mInt64(base_compaction_interval_seconds_since_last_operation, \"86400\")"
+
+  - name: "min_cumulative_compaction_num_singleton_deltas"
+    type: Int64
+    default: 5
+    scope: "BE config"
+    mutable: true
+    description: >
+      Minimum number of singleton delta rowsets required before a
+      cumulative compaction is triggered.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 368
+          context: "CONF_mInt64(min_cumulative_compaction_num_singleton_deltas, \"5\")"
+
+  - name: "max_cumulative_compaction_num_singleton_deltas"
+    type: Int64
+    default: 500
+    scope: "BE config"
+    mutable: true
+    description: >
+      Maximum number of singleton delta rowsets that can be included in
+      a single cumulative compaction.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 369
+          context: "CONF_mInt64(max_cumulative_compaction_num_singleton_deltas, \"500\")"
+
+  - name: "manual_compaction_threads"
+    type: Int32
+    default: 4
+    scope: "BE config"
+    mutable: false
+    description: >
+      Number of threads used for manually triggered compaction operations.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 401
+          context: "CONF_Int32(manual_compaction_threads, \"4\")"
+
+  - name: "min_cumulative_compaction_failure_interval_sec"
+    type: Int64
+    default: 30
+    scope: "BE config"
+    mutable: true
+    description: >
+      Minimum interval in seconds between retries after a failed cumulative
+      compaction.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 407
+          context: "CONF_mInt64(min_cumulative_compaction_failure_interval_sec, \"30\")"
+
+  # ---------------------------------------------------------------------------
+  # Storage page and cache
+  # ---------------------------------------------------------------------------
+
+  - name: "data_page_size"
+    type: Int32
+    default: 65536
+    scope: "BE config"
+    mutable: false
+    description: >
+      Size of data and index pages in bytes. Default is 64KB.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 331
+          context: "CONF_Int32(data_page_size, \"65536\")"
+
+  - name: "disable_storage_page_cache"
+    type: boolean
+    default: false
+    scope: "BE config"
+    mutable: true
+    description: >
+      Whether to disable the storage page cache entirely.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 341
+          context: "CONF_mBool(disable_storage_page_cache, \"false\")"
+
+  # ---------------------------------------------------------------------------
+  # Worker threads
+  # ---------------------------------------------------------------------------
+
+  - name: "number_tablet_writer_threads"
+    type: Int32
+    default: 0
+    scope: "BE config"
+    mutable: true
+    description: >
+      Number of threads for tablet writer operations. 0 means auto-detected
+      based on available CPU cores.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 541
+          context: "CONF_mInt32(number_tablet_writer_threads, \"0\")"
+
+  - name: "tablet_writer_open_rpc_timeout_sec"
+    type: Int32
+    default: 300
+    scope: "BE config"
+    mutable: true
+    description: >
+      Timeout in seconds for the tablet writer open RPC call during data
+      loading.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 591
+          context: "CONF_mInt32(tablet_writer_open_rpc_timeout_sec, \"300\")"
+
+  - name: "txn_commit_rpc_timeout_ms"
+    type: Int32
+    default: 60000
+    scope: "BE config"
+    mutable: true
+    description: >
+      Timeout in milliseconds for the transaction commit RPC call.
+    code_references:
+      definition:
+        - file: "be/src/common/config.h"
+          line: 771
+          context: "CONF_mInt32(txn_commit_rpc_timeout_ms, \"60000\")"

--- a/param-docs/README.md
+++ b/param-docs/README.md
@@ -1,0 +1,73 @@
+# StarRocks Parameter Dictionary
+
+Comprehensive reference for all session variables and configuration parameters in the StarRocks codebase.
+
+## Source Files
+
+| Source | File | Count |
+|--------|------|-------|
+| FE Session Variables | `fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java` | ~278 |
+| FE Global Config | `fe/fe-core/src/main/java/com/starrocks/common/Config.java` | ~779 |
+| BE Config | `be/src/common/config.h` | ~718 |
+| Thrift (FE→BE) | `gensrc/thrift/InternalService.thrift` (TQueryOptions) | ~107 |
+
+## Category Files
+
+| # | File | Description |
+|---|------|-------------|
+| 01 | `01_query_optimization.yml` | CBO rules, rewrite toggles, predicate pushdown |
+| 02 | `02_join_optimization.yml` | Hash join, broadcast, shuffle, runtime filter |
+| 03 | `03_scan_and_io.yml` | Scan limits, split sizes, data cache |
+| 04 | `04_parquet_orc_reader.yml` | Page index, bloom filter, lazy materialization |
+| 05 | `05_memory_management.yml` | Memory limits, spill settings |
+| 06 | `06_parallelism_scheduling.yml` | Pipeline, DOP, concurrency |
+| 07 | `07_materialized_views.yml` | MV refresh, rewrite, planning |
+| 08 | `08_external_catalogs.yml` | Hive, Iceberg, JDBC connectors |
+| 09 | `09_network_timeout.yml` | RPC timeouts, connection settings |
+| 10 | `10_statistics_cost_estimation.yml` | CBO statistics, histogram, sampling |
+| 11 | `11_security_authentication.yml` | Auth, encryption, access control |
+| 12 | `12_logging_debugging.yml` | Log levels, profiling, debug flags |
+| 13 | `13_general_system.yml` | Catch-all for uncategorized params |
+
+## YAML Entry Format
+
+```yaml
+- name: "variable_sql_name"
+  type: Boolean | Integer | Long | Double | String
+  default: <value>
+  scope: "FE session variable" | "FE global config" | "BE config" | combination
+  mutable: true | false
+  description: >
+    1-3 sentences explaining what it controls.
+  code_references:
+    definition:
+      - file: "path/to/file"
+        line: NNN
+        context: "brief context"
+    usage:
+      - file: "path/to/file"
+        line: NNN
+        context: "how the variable changes behavior"
+    thrift_propagation:
+      - file: "gensrc/thrift/InternalService.thrift"
+        line: NNN
+        context: "Field N in TQueryOptions"
+  behavior:
+    "true": "what happens when enabled"
+    "false": "what happens when disabled"
+  related_variables:
+    - "other_variable_name"
+```
+
+## Legend
+
+- **scope**: Where the parameter is defined and takes effect
+  - `FE session variable` — set per-session via `SET variable = value`
+  - `FE global config` — set in `fe.conf` or via `ADMIN SET FRONTEND CONFIG`
+  - `BE config` — set in `be.conf` or via HTTP API
+  - Combinations indicate the variable exists in multiple scopes
+- **mutable**: Whether it can be changed at runtime without restart
+  - For BE configs, the `m` prefix on macros (e.g., `CONF_mBool`) indicates mutable
+  - For FE configs, `@ConfField(mutable = true)` indicates mutable
+- **thrift_propagation**: Variables propagated from FE to BE per-query via `TQueryOptions`
+- **behavior**: What changes when the value is toggled (for booleans) or varied (for numerics)


### PR DESCRIPTION
## Summary

Adds `param-docs/` directory: a comprehensive YAML dictionary of all ~1,775 StarRocks session variables and BE/FE configuration parameters.

**Depends on:** #10 (sync with upstream) — merge that first, then retarget this PR to `main`.

## Contents

13 category files + README, totaling ~11,900 lines:

| File | Description |
|------|-------------|
| `01_query_optimization.yml` | CBO rules, rewrite toggles, predicate pushdown |
| `02_join_optimization.yml` | Hash join, broadcast, shuffle, runtime filter |
| `03_scan_and_io.yml` | Scan limits, split sizes, data cache |
| `04_parquet_orc_reader.yml` | Page index, bloom filter, late materialization |
| `05_memory_management.yml` | Memory limits, spill settings |
| `06_parallelism_scheduling.yml` | Pipeline, DOP, concurrency |
| `07_materialized_views.yml` | MV refresh, rewrite, planning |
| `08_external_catalogs.yml` | Hive, Iceberg, JDBC connectors |
| `09_network_timeout.yml` | RPC timeouts, connection settings |
| `10_statistics_cost_estimation.yml` | CBO statistics, histogram, sampling |
| `11_security_authentication.yml` | Auth, encryption, access control |
| `12_logging_debugging.yml` | Log levels, profiling, debug flags |
| `13_general_system.yml` | General/system parameters |

Each entry includes: name, type, default value, scope, mutability, description, code references with exact file paths and line numbers, thrift propagation, and behavioral impact.

Made with [Cursor](https://cursor.com)