### PR TITLE
fix(fe): re-apply spark2-profile spark 2.4.6 -> 3.3.3 (CVE-2023-22946)

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -100,7 +100,7 @@ under the License.
         <profile>
             <id>spark2</id>
             <properties>
-                <spark.version>2.4.6</spark.version>
+                <spark.version>3.3.3</spark.version>
             </properties>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
## Summary

Re-apply the **one** CVE patch from PR #19 that upstream's `main` did not address. PR #19's bulk fix was reverted as part of the upstream sync (#21).

| PR #19 patch | Post-sync upstream state | Re-apply? |
|---|---|---|
| `tomcat-embed-core` 9.0.106→9.0.116 (hdfs-broker) | **9.0.117** | ❌ Upstream newer than the patch |
| `ranger-plugins-common` 2.5.0→2.8.0 (fe) | **2.8.0** in `fe/pom.xml` | ❌ Already at fix version |
| `axios` 1.7.8→1.15.0 (docusaurus) | axios no longer in `docs/docusaurus/yarn.lock` at all | ❌ Dep removed upstream |
| `form-data` (via axios resolution) | axios gone | ❌ N/A |
| `basic-ftp` 5.0.5→5.3.1 (docusaurus-pdf) | `docs/docusaurus/PDF/` directory deleted upstream | ❌ N/A |
| `axios` no-op / `tomcat` no-op | n/a | ❌ N/A |
| **`spark-core_2.12` 2.4.6→3.3.3 (fe spark2 profile, activeByDefault)** | **still 2.4.6** in `fe/pom.xml` | ✅ **This PR** |
| `apache-orc` 1.7.0→2.1.2 (be CMake) | still `1.7.0-SNAPSHOT` | ⚠️ See note |

## Why only spark2?

After the upstream sync, audit shows:

- **tomcat (hdfs-broker)** — upstream `<tomcat.version>9.0.117</tomcat.version>` already exceeds PR #19's 9.0.116.
- **ranger-plugins-common (fe)** — upstream `fe/pom.xml` already pins `<version>2.8.0</version>`. Same as PR #19.
- **axios / form-data / basic-ftp (docusaurus)** — upstream removed the affected deps entirely; `docs/docusaurus/PDF/` no longer exists; `axios` no longer appears in `docs/docusaurus/yarn.lock`. Re-applying these patches would fail (target files/deps don't exist).
- **spark2 profile** — upstream `fe/pom.xml` still pins `<spark.version>2.4.6</spark.version>` inside the `spark2` Maven profile, which is `activeByDefault=true`. **This CVE re-emerges post-sync.** ⇒ Re-applied here.

## What this PR does NOT include — apache-orc

PR #19 commit `4d40a0a2` bumped `be/src/formats/orc/apache-orc/CMakeLists.txt` from version string `1.7.0-SNAPSHOT` to `2.1.2`. After inspection, that change is **cosmetic only**:

- `be/src/formats/orc/apache-orc/` is **vendored ORC source code**, not a downloaded artifact.
- The CMake `CPACK_PACKAGE_VERSION_*` macros control what version string the build labels itself with — they do **not** swap in newer ORC source code.
- Upstream StarRocks maintains the vendored ORC by cherry-picking individual upstream-ORC fixes (e.g. #60722 "Cherry-Pick ORC-1525 bugfix"), not by wholesale source replacement.
- Bumping the version string would silence scanner heuristics that read the CMake metadata but would leave the vulnerable 1.7.0-era C++ source in place — **a real-fix gap dressed up as a fix**.

CVE-2025-47436 (CVSS 6.0) still applies to the vendored code. Proper remediation requires either (a) cherry-picking the specific upstream-ORC fix commit for CVE-2025-47436 into `be/src/formats/orc/apache-orc/c++/`, or (b) accepting and documenting the residual risk. **Not done in this PR.**

## Test plan

- [ ] FE Maven build succeeds against `fe/pom.xml` change (`./build.sh --fe`)
- [ ] Existing spark-related FE unit tests still pass
- [ ] No new checkstyle violations introduced (single-line POM change)
