### PR TITLE
fix(deps): clear 38 of 39 dependabot alerts (log4j, netty, grpc, kafka, commons-lang3, et al.)

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -49,7 +49,7 @@ jobs:
           echo "bucket_prefix=${bucket_prefix}" >> $GITHUB_OUTPUT
 
       - name: Download workflow artifact - PR
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}

--- a/contrib/trino-connector/pom.xml
+++ b/contrib/trino-connector/pom.xml
@@ -14,7 +14,7 @@
         <air.main.basedir>${project.basedir}</air.main.basedir>
         <dep.airlift.version>230</dep.airlift.version>
         <dep.airlift.units.version>1.8</dep.airlift.units.version>
-        <dep.jackson.version>2.15.0</dep.jackson.version>
+        <dep.jackson.version>2.18.6</dep.jackson.version>
         <dep.guava.version>32.0.0-jre</dep.guava.version>
         <dep.guice.version>6.0.0</dep.guice.version>
         <dep.drift.version>1.14</dep.drift.version>
@@ -291,7 +291,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.18.1</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -40,7 +40,17 @@
     "serve-handler": {
       "path-to-regexp": "3.3.0"
     },
-    "webpack-dev-middleware": "5.3.4"
+    "webpack-dev-middleware": "5.3.4",
+    "postcss": "8.5.10",
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
+    "fast-uri": "3.1.2",
+    "serialize-javascript": "7.0.5"
+  },
+  "resolutions": {
+    "postcss": "8.5.10",
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
+    "fast-uri": "3.1.2",
+    "serialize-javascript": "7.0.5"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.0",

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -288,7 +288,7 @@ under the License.
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -48,7 +48,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.8.2</junit.version>
         <jprotobuf-starrocks.version>1.0.0</jprotobuf-starrocks.version>
-        <log4j.version>2.19.0</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <jackson.version>2.21.1</jackson.version>
         <!-- jackson-annotations doesn't have 2.21.1 version released -->
         <jackson-annotations.version>2.21</jackson-annotations.version>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -263,7 +263,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.9</version>
+                <version>3.18.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-pool2 -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -67,15 +67,15 @@ under the License.
         <odps.version>0.48.7-public</odps.version>
         <kudu.version>1.17.1</kudu.version>
         <hikaricp.version>7.0.2</hikaricp.version>
-        <kafka-clients.version>3.9.1</kafka-clients.version>
+        <kafka-clients.version>3.9.2</kafka-clients.version>
         <arrow.version>18.0.0</arrow.version>
-        <grpc.version>1.63.0</grpc.version>
-        <io.netty.version>4.1.133.Final</io.netty.version>
+        <grpc.version>1.75.0</grpc.version>
+        <io.netty.version>4.2.13.Final</io.netty.version>
         <puppycrawl.version>10.21.1</puppycrawl.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>
         <avro.version>1.12.0</avro.version>
         <dnsjava.version>3.6.3</dnsjava.version>
-        <nimbusds.version>9.37.2</nimbusds.version>
+        <nimbusds.version>9.37.4</nimbusds.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <paimon.version>1.3.1</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>

--- a/format-sdk/pom.xml
+++ b/format-sdk/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/format-sdk/pom.xml
+++ b/format-sdk/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.0.33</version>
+            <version>8.2.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/format-sdk/pom.xml
+++ b/format-sdk/pom.xml
@@ -86,19 +86,19 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.24.1</version>
+            <version>2.25.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.24.1</version>
+            <version>2.25.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.24.1</version>
+            <version>2.25.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -186,7 +186,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.3.2</version>
+                <version>3.18.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -46,7 +46,7 @@ under the License.
         <protobuf.version>3.25.5</protobuf.version>
         <thrift.version>0.22.0</thrift.version>
         <tomcat.version>9.0.117</tomcat.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <jackson.version>2.21.1</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <avro.version>1.11.4</avro.version>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -36,7 +36,7 @@
         <hadoop.version>3.4.3</hadoop.version>
         <zookeeper.version>3.8.6</zookeeper.version>
         <iceberg.version>1.10.0</iceberg.version>
-        <log4j2.version>2.23.1</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
         <junit.version>5.10.3</junit.version>
         <hive-apache.version>3.1.2-22</hive-apache.version>
         <jni-connector.version>1.0.0</jni-connector.version>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -42,9 +42,9 @@
         <jni-connector.version>1.0.0</jni-connector.version>
         <hadoop-ext.version>1.0.0</hadoop-ext.version>
         <java-utils.version>1.0.0</java-utils.version>
-        <io.netty.version>4.1.133.Final</io.netty.version>
+        <io.netty.version>4.2.13.Final</io.netty.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
-        <nimbusds.version>9.37.2</nimbusds.version>
+        <nimbusds.version>9.37.4</nimbusds.version>
         <commons-io.version>2.14.0</commons-io.version>
         <gcs.connector.version>3.0.13</gcs.connector.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/java-extensions/udf-extensions/pom.xml
+++ b/java-extensions/udf-extensions/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.18.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

One-shot fork patch sweep to clear dependabot's open alert list (was 39: 12 high, 26 moderate, 1 low). Each commit targets one package family for easy revert if any specific bump breaks the build.

## Alerts addressed (38 of 39)

### Maven runtime deps — commit-by-commit

| Commit | Package | Change | Alerts cleared |
|---|---|---|---|
| `ca207d5e` | **log4j** family | property bumps to `2.25.4` in `fe/pom.xml` (2.19.0), `fs_brokers/apache_hdfs_broker/src/pom.xml` (2.17.1), `java-extensions/pom.xml` (`<log4j2.version>` 2.23.1), `format-sdk/pom.xml` (hardcoded 2.24.1, test scope) | 16 (GHSA-6hg6×4, -445c×2, -h383, -3pxv×4, -w35j, -vc5p×4, -h383) |
| `ba314cc0` | **kafka-clients** | `3.9.1 → 3.9.2` in `fe/pom.xml` | 2 (GHSA-wf66, -5qcv) |
| `ba314cc0` | **nimbus-jose-jwt** | `9.37.2 → 9.37.4` in `fe/pom.xml` + `java-extensions/pom.xml` | 2 (GHSA-xwmg×2) |
| `ba314cc0` | **grpc-netty-shaded** | `grpc.version 1.63.0 → 1.75.0` in `fe/pom.xml` | 1 (GHSA-prj3) |
| `ba314cc0` | **netty-transport-native-epoll** | `io.netty.version 4.1.133.Final → 4.2.13.Final` in `fe/pom.xml` + `java-extensions/pom.xml` | 1 (GHSA-rwm7) ⚠️ major-line bump |
| `9af5b86e` | **commons-lang3** | `3.9` / `3.3.2 → 3.18.0` in 4 poms | 4 (GHSA-j288×4) |
| `f4e32b9f` | **jackson-core** | `dep.jackson.version 2.15.0 → 2.18.6` in `contrib/trino-connector/pom.xml` | 1 (GHSA-72hv) |
| `f4e32b9f` | **mysql-connector-j** | `8.0.33 → 8.2.0` (test scope) in `format-sdk/pom.xml` | 1 (GHSA-m6vm) |
| `f4e32b9f` | **assertj-core** | `3.24.2` / `3.18.1 → 3.27.7` (test scope) in `fe/fe-core/pom.xml` + `contrib/trino-connector/pom.xml` | 2 (GHSA-rqfh×2) |

### CI workflow

| Commit | Change | Alerts cleared |
|---|---|---|
| `30aa2628` | `dawidd6/action-download-artifact@v3 → @v6` in `.github/workflows/ci-report.yml` | 1 (GHSA-5xr6) |

### npm transitives (docs site)

| Commit | Change | Alerts cleared |
|---|---|---|
| `a2f5b915` | Add `resolutions` + `overrides` to `docs/docusaurus/package.json` pinning `postcss@8.5.10`, `@babel/plugin-transform-modules-systemjs@7.29.4`, `fast-uri@3.1.2`, `serialize-javascript@7.0.5`. `yarn.lock` regenerates on next install. | 6 (GHSA-qx2v, -fv7c, -v39h, -q3j6, -qj8w, -5c6j) |

### Not in this PR

- **`commons-configuration` GHSA-pvp8-3xj6-8c6x** (low): no fix version released. Recommend a dependabot suppression with rationale instead. **1 alert remains after this PR merges.**

## Risk callouts

- **netty 4.1.133.Final → 4.2.13.Final**: this crosses a major minor-line. Netty maintains source-compat across 4.x in practice but ABI/perf can drift. Watch FE build + integration tests.
- **grpc 1.63 → 1.75**: 12 minor versions; gRPC keeps API compat but watch for deprecations.
- **commons-lang3 3.9/3.3.2 → 3.18.0**: large range; a few methods deprecated in 3.13+. If FE/format-sdk compile fails, narrow to the highest 3.x that fixes GHSA-j288.
- **log4j 2.17/2.19 → 2.25.4**: minor bumps, low risk.
- **assertj/jackson/mysql-j**: test-scope or low-blast-radius single-call-site deps.

## Test plan

- [ ] FE build green: `./build.sh --fe`
- [ ] java-extensions build green: `cd java-extensions && mvn package -DskipTests`
- [ ] format-sdk build green
- [ ] hdfs-broker build green
- [ ] FE unit tests pass (`./run-fe-ut.sh`)
- [ ] Docusaurus build green (`cd docs/docusaurus && yarn install && yarn build`)
- [ ] Dependabot alert count drops to 1 (the commons-configuration low) after merge

## Companion / context

- Builds on top of #21 (upstream sync to `StarRocks/main` HEAD `7c9afa8d`).
- #22 separately re-applies spark2-profile spark CVE-2023-22946 which dependabot doesn't pick up (maven-profile pin).
- Supersedes the stale dependabot group PRs #1, #2, #6, #14, #15. Recommend closing those after this lands.
- #16 (mysql-connector-python test dep) and #18 (node-forge in docusaurus) are independent — keep them.
